### PR TITLE
v0.1.2

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,5 +1,6 @@
 var fs = require("fs"),
     extended = require("./extended"),
+    isUndefinedOrNull = extended.isUndefinedOrNull,
     hash = extended.hash,
     stream = require("stream"),
     LINE_BREAK = (process.platform === 'win32' ? '\r\n' : '\n');
@@ -29,11 +30,13 @@ function createFormatter(options) {
     }
 
     return function escapeFields(fields) {
-        var i = -1, l = fields.length, ret = [];
+        var i = -1, l = fields.length, ret = [], field;
         while (++i < l) {
-            ret.push(escapeField(fields[i]));
+            field = fields[i];
+            field = (isUndefinedOrNull(field) ? "" : field) + "";
+            ret.push(escapeField(field));
         }
-        return ret.join(delimiter) + LINE_BREAK;
+        return ret.join(delimiter);
     };
 }
 
@@ -59,7 +62,7 @@ function __write(writer, arr, options) {
             item = arr[i];
             ret.push(formatter(isHash ? hash.values(item) : item));
         }
-        writer.push(ret.join(""));
+        writer.push(ret.join("\n"));
     }
 }
 
@@ -71,11 +74,7 @@ function write(arr, options) {
 }
 
 function writeToStream(ws, arr, options) {
-    var writer = new stream.Readable();
-    __write(writer, arr, options);
-    writer.push(null);
-    writer.pipe(ws);
-    return writer;
+    return write(arr, options).pipe(ws);
 }
 
 function writeToString(arr, options) {

--- a/lib/parser_stream.js
+++ b/lib/parser_stream.js
@@ -36,9 +36,28 @@ function ParserStream(options) {
 
 util.inherits(ParserStream, stream.Transform);
 
-var origOn = ParserStream.prototype.on;
+var origOn = ParserStream.prototype.on,
+    origPause = ParserStream.prototype.pause,
+    origResume = ParserStream.prototype.resume;
+
+function pause() {
+    origPause.apply(this, arguments);
+    this.paused = true;
+    this.pause = pause;
+}
+
+function resume() {
+    origResume.apply(this, arguments);
+    this.paused = false;
+    if (this.__pausedDone) {
+        this.__pausedDone();
+    }
+    this.resume = resume;
+}
 
 extended(ParserStream).extend({
+
+    __pausedDone: null,
 
     __parseLine: function __parseLineData(data, index, ignore) {
         var ignoreEmpty = this._ignoreEmpty;
@@ -111,7 +130,11 @@ extended(ParserStream).extend({
         } else {
             this.lines += data;
         }
-        done();
+        if (!this.paused) {
+            done();
+        } else {
+            this.__pausedDone = done;
+        }
     },
 
     _flush: function (callback) {
@@ -125,6 +148,25 @@ extended(ParserStream).extend({
     },
     __transform: function (data, index) {
         return data;
+    },
+
+    pause: function () {
+        if (!this.paused) {
+            this.paused = true;
+            this.emit("pause");
+        }
+    },
+
+    resume: function () {
+        if (this.paused) {
+            this.paused = false;
+            if (this.__pausedDone) {
+                var done = this.__pausedDone;
+                this.__pausedDone = null;
+                done();
+            }
+            this.emit("resume");
+        }
     },
 
     on: function (evt) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fast-csv",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "CSV parser for node.js",
     "main": "index.js",
     "scripts": {

--- a/test/fast-csv.test.js
+++ b/test/fast-csv.test.js
@@ -523,7 +523,7 @@ it.describe("fast-csv parser", function (it) {
         it.should("write an array of arrays", function (next) {
             var ws = new stream.Writable();
             ws._write = function (data) {
-                assert.deepEqual(data.toString(), "a,b\na1,b1\na2,b2\n");
+                assert.deepEqual(data.toString(), "a,b\na1,b1\na2,b2");
                 next();
             };
             csv.writeToStream(ws, [
@@ -536,7 +536,7 @@ it.describe("fast-csv parser", function (it) {
         it.should("write an array of objects", function (next) {
             var ws = new stream.Writable();
             ws._write = function (data) {
-                assert.deepEqual(data.toString(), "a,b\na1,b1\na2,b2\n");
+                assert.deepEqual(data.toString(), "a,b\na1,b1\na2,b2");
                 next();
             };
             csv.writeToStream(ws, [
@@ -553,14 +553,14 @@ it.describe("fast-csv parser", function (it) {
                 ["a", "b"],
                 ["a1", "b1"],
                 ["a2", "b2"]
-            ], {headers: true}), "a,b\na1,b1\na2,b2\n");
+            ], {headers: true}), "a,b\na1,b1\na2,b2");
         });
 
         it.should("write an array of objects", function () {
             assert.equal(csv.writeToString([
                 {a: "a1", b: "b1"},
                 {a: "a2", b: "b2"}
-            ], {headers: true}), "a,b\na1,b1\na2,b2\n");
+            ], {headers: true}), "a,b\na1,b1\na2,b2");
         });
     });
 
@@ -569,7 +569,7 @@ it.describe("fast-csv parser", function (it) {
         it.should("write an array of arrays", function (next) {
             var ws = new stream.Writable();
             ws._write = function (data) {
-                assert.deepEqual(data.toString(), "a,b\na1,b1\na2,b2\n");
+                assert.deepEqual(data.toString(), "a,b\na1,b1\na2,b2");
                 next();
             };
             csv.write([
@@ -582,7 +582,7 @@ it.describe("fast-csv parser", function (it) {
         it.should("write an array of objects", function (next) {
             var ws = new stream.Writable();
             ws._write = function (data) {
-                assert.deepEqual(data.toString(), "a,b\na1,b1\na2,b2\n");
+                assert.deepEqual(data.toString(), "a,b\na1,b1\na2,b2");
                 next();
             };
             csv.write([
@@ -602,7 +602,7 @@ it.describe("fast-csv parser", function (it) {
                 ["a2", "b2"]
             ], {headers: true})
                 .on("finish", function () {
-                    assert.equal(fs.readFileSync(path.resolve(__dirname, "assets/test.csv")).toString(), "a,b\na1,b1\na2,b2\n");
+                    assert.equal(fs.readFileSync(path.resolve(__dirname, "assets/test.csv")).toString(), "a,b\na1,b1\na2,b2");
                     fs.unlinkSync(path.resolve(__dirname, "assets/test.csv"));
                     next();
                 });
@@ -615,10 +615,12 @@ it.describe("fast-csv parser", function (it) {
                 {a: "a2", b: "b2"}
             ], {headers: true})
                 .on("finish", function () {
-                    assert.equal(fs.readFileSync(path.resolve(__dirname, "assets/test.csv")).toString(), "a,b\na1,b1\na2,b2\n");
+                    assert.equal(fs.readFileSync(path.resolve(__dirname, "assets/test.csv")).toString(), "a,b\na1,b1\na2,b2");
                     fs.unlinkSync(path.resolve(__dirname, "assets/test.csv"));
                     next();
                 });
         });
     });
 });
+
+it.run();


### PR DESCRIPTION
- Fixed issue with formatter handling undefined or null values.
- Changed formatter not not include a new line at the end of a CSV.
- Added `pause` and `resume` functionality to `ParserStream`
