### PR TITLE
v0.2.5

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,9 +1,13 @@
-#0.2.4
+# v0.2.5
+
+* Fixed issue where not all rows are emitted when using `pause` and `resume`
+
+# v0.2.4
 
 * Added more fine grained control to `.pause` and `.resume`
    * You can now pause resume between chunks
 
-# 0.2.3
+# v0.2.3
 
 * Add new `createWriteStream` for creating a streaming csv writer
 

--- a/docs/History.html
+++ b/docs/History.html
@@ -176,14 +176,18 @@
 
 
 
-<h1>0.2.4</h1>
+<h1>v0.2.5</h1>
+<ul>
+<li>Fixed issue where not all rows are emitted when using <code>pause</code> and <code>resume</code></li>
+</ul>
+<h1>v0.2.4</h1>
 <ul>
 <li>Added more fine grained control to <code>.pause</code> and <code>.resume</code><ul>
 <li>You can now pause resume between chunks</li>
 </ul>
 </li>
 </ul>
-<h1>0.2.3</h1>
+<h1>v0.2.3</h1>
 <ul>
 <li>Add new <code>createWriteStream</code> for creating a streaming csv writer</li>
 </ul>

--- a/lib/parser_stream.js
+++ b/lib/parser_stream.js
@@ -175,8 +175,8 @@ extended(ParserStream).extend({
             this.paused = false;
             var buffered = this.__buffered, l = buffered.length;
             if (l) {
-                var i = -1, entry;
-                while (++i < buffered.length) {
+                var entry;
+                while (buffered.length) {
                     entry = buffered.shift();
                     this.__emitRecord(entry[0], entry[1]);
                     //handle case where paused is called while emitting data

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fast-csv",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "description": "CSV parser and writer",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
- Fixed issue where not all rows are emitted when using `pause` and `resume`
