### PR TITLE
Fix headers ordering bug.  Add testing demoing bug.

### DIFF
--- a/lib/formatter/formatter.js
+++ b/lib/formatter/formatter.js
@@ -129,7 +129,7 @@ function checkHeaders(stream, item) {
     }
     if (!stream.hasWrittenHeaders) {
         stream.totalCount++;
-        stream.push(new Buffer(stream.formatter(headers, true), "utf8"));
+        stream.push(new Buffer(stream.formatter(stream.headers, true), "utf8"));
         stream.hasWrittenHeaders = true;
         ret = isHashArray(item) || !isArray(item);
     }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "grunt-it": "~0.3.1",
         "grunt": "~0.4.1",
         "grunt-contrib-jshint": "~0.10.0",
-        "grunt-exec": "^0.4.5"
+        "grunt-exec": "^0.4.5",
+        "event-stream": "^3.1.7"
     },
     "engines": {
         "node": ">=0.10"

--- a/test/headersbug.test.js
+++ b/test/headersbug.test.js
@@ -1,0 +1,15 @@
+var it = require("it"),
+    assert = require("assert"),
+    es = require("event-stream"),
+    csv = require("../index");
+
+it.describe("formatting headers", function (it) {
+    it.should("be possible by giving an ordered array", function (next) {
+        var input = es.readArray([{first: "1", second: "2"}]);
+        var csvStream = csv.createWriteStream({headers: ["second", "first"]});
+        input.pipe(csvStream).pipe(es.writeArray(function (err, array) {
+            assert.deepEqual(array.join(""), "second,first\n2,1");
+            next();
+        }));
+    });
+});


### PR DESCRIPTION
Passing {headers: []} was breaking due to use of a local variable uninitialised under certain conditions.
Fix is to use the instance variable, which was already being set correctly.
Tests introduce dev dependency of event-stream for convenience
- You may want to re-write to suit project style
