### PR TITLE
Fix for when chunk returned by transform to the parser ends with a space

### DIFF
--- a/lib/parser/parser.js
+++ b/lib/parser/parser.js
@@ -147,6 +147,7 @@ function createParser(options) {
             token = nextToken.token;
             if (isUndefinedOrNull(token)) {
                 i = lastLineI;
+                cursor = null;
                 break;
             } else if (ROW_DELIMITER.test(token)) {
                 i = nextToken.cursor + 1;

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -68,6 +68,16 @@ it.describe("fast-csv parser", function (it) {
                 });
             });
 
+            it.should("not parse a row if there is a trailing delimiter with a space, and there is more data", function () {
+                var data = "first_name,last_name,email_address, ";
+                var myParser = parser({delimiter: ","});
+                var parsedData = myParser(data, true);
+                assert.deepEqual(parsedData, {
+                    "line": "first_name,last_name,email_address, ",
+                    "rows": []
+                });
+            });
+
             it.should("parse a row if a new line is found and there is more data", function () {
                 var data = "first_name,last_name,email_address\n";
                 var myParser = parser({delimiter: ","});


### PR DESCRIPTION
Changes
---
- When the data chunk returned by transform to the parser ends with a
space and there is more data, do not process the row, but wait until the
next chunk comes in to process that row
- Added test case to support the issue

Background
---
We were trying to parse a file with rows that looked like:
`val1, ,val3, , ,val6,val7` where `, ,` represents a null or empty string

The stream Transform splits large files into chunks of data at random points in the rows (due to char/highWaterLimits) and this was causing in one case the row to be split after the `, ` so the chunk ended with a space. Thankfully the parser was smart enough to identify it, but it was ending the parse line loop with an undefined token leaving the cursor as a valid(and old) value so when the loop broke out  due to undefined token, it would add the partial row.

Hopefully this is the correct fix. I understand the code and what its doing, but I didn't write the parser, so there may be a very good reason for not nulling the cursor in that null token check. All tests passed though.