### PR TITLE
Functionality to give a reason when invalid data

### DIFF
--- a/lib/parser/parser_stream.js
+++ b/lib/parser/parser_stream.js
@@ -63,13 +63,13 @@ extended(ParserStream).extend({
                 if (err) {
                     next(err);
                 } else {
-                    self.__validate(line, function (err, isValid) {
+                    self.__validate(line, function (err, isValid, reason) {
                         if (err) {
                             next(err);
                         } else if (isValid) {
                             next(null, line);
                         } else {
-                            self.emit("data-invalid", line, index);
+                            self.emit("data-invalid", line, index, reason);
                             next(null, null);
                         }
                     });


### PR DESCRIPTION
Would be nice to know why some row failed the validation when parsing big csv's and have multiple validation criteria.

My simple change just makes it possible to do: 

    csv.fromPath('some/path.csv').validate(function(data, cb) {
        // INVALID!
        cb(null, false, "Invalid because...");
    }).on('data-invalid', function(data, index, reason) {
        console.log("Invalid because: %s", reason);
    });

    