### PR TITLE
Allow skipping corrupted lines during parsing

### DIFF
--- a/lib/parser/parser.js
+++ b/lib/parser/parser.js
@@ -11,6 +11,7 @@ function createParser(options) {
         doLtrim = options.ltrim || false,
         doRtrim = options.rtrim || false,
         doTrim = options.trim || false,
+        handleError = options.handleError || function(err) { throw err; },
         ESCAPE = has(options, "quote") ? options.quote : '"',
         VALUE_REGEXP = new RegExp("([^" + delimiter + "'\"\\s\\\\]*(?:\\s+[^" + delimiter + "'\"\\s\\\\]+)*)"),
         SEARCH_REGEXP = new RegExp("(?:\\n|\\r|" + delimiter + ")"),
@@ -35,7 +36,7 @@ function createParser(options) {
     }
 
     function parseEscapedItem(str, items, cursor, hasMoreData) {
-        var depth = 0, ret = [];
+        var depth = 0, ret = [], corrupt = false;
         var startPushing = false, token, i = 0, l = str.length, escapeIsEscape = ESCAPE_CHAR === ESCAPE;
         if (l) {
             while (cursor < l && (token = str.charAt(cursor))) {
@@ -73,17 +74,22 @@ function createParser(options) {
             if (hasMoreData) {
                 cursor = null;
             } else {
-                throw new Error("Parse Error: expected: '" + ESCAPE + "' got: '" + nextToken + "'. at '" + str.substr(cursor).replace(/[r\n]/g, "\\n" + "'"));
+                handleError(new Error("Parse Error: expected: '" + ESCAPE + "' got: '" + nextToken + "'. at '" + str.substr(cursor).replace(/[r\n]/g, "\\n" + "'")));
+                corrupt = true;
             }
         } else if ((!depth && nextToken && nextToken.search(SEARCH_REGEXP) === -1)) {
-            throw new Error("Parse Error: expected: '" + ESCAPE + "' got: '" + nextToken + "'. at '" + str.substr(cursor, 10).replace(/[\r\n]/g, "\\n" + "'"));
+            handleError(new Error("Parse Error: expected: '" + ESCAPE + "' got: '" + nextToken + "'. at '" + str.substr(cursor, 10).replace(/[\r\n]/g, "\\n" + "'")));
+            corrupt = true;
         } else if (hasMoreData && (!nextToken || !ROW_DELIMITER.test(nextToken))) {
             cursor = null;
         }
-        if (cursor !== null) {
+        if (cursor !== null && !corrupt) {
             items.push(formatItem(ret));
         }
-        return cursor;
+        return {
+            cursor: cursor,
+            corrupt: corrupt
+        };
     }
 
     function parseCommentLine(line, cursor, hasMoreData) {
@@ -102,33 +108,42 @@ function createParser(options) {
 
     function parseItem(line, items, cursor, hasMoreData) {
         var searchStr = line.substr(cursor),
-            nextIndex = searchStr.search(SEARCH_REGEXP);
+            nextIndex = searchStr.search(SEARCH_REGEXP),
+            corrupt = false;
+            
         if (nextIndex === -1) {
             if (!VALUE_REGEXP.test(searchStr)) {
-                throw new Error("Parse Error: delimiter '" + delimiter + "' not found at '" + searchStr.replace(/\n/g, "\\n" + "'"));
+                handleError(new Error("Parse Error: delimiter '" + delimiter + "' not found at '" + searchStr.replace(/\n/g, "\\n" + "'")));
+                corrupt = true;
             } else {
                 nextIndex = searchStr.length;
             }
         }
-        var nextChar = searchStr.charAt(nextIndex);
-        if (nextChar.search(delimiter) !== -1) {
-            if (hasMoreData && (cursor + (nextIndex + 1) >= line.length)) {
-                cursor = null;
-            } else {
+        
+        if (!corrupt) {
+            var nextChar = searchStr.charAt(nextIndex);
+            if (nextChar.search(delimiter) !== -1) {
+                if (hasMoreData && (cursor + (nextIndex + 1) >= line.length)) {
+                    cursor = null;
+                } else {
+                    items.push(formatItem(searchStr.substr(0, nextIndex)));
+                    cursor += nextIndex + 1;
+                }
+            } else if (ROW_DELIMITER.test(nextChar)) {
+                items.push(formatItem(searchStr.substr(0, nextIndex)));
+                cursor += nextIndex;
+            } else if (!hasMoreData) {
                 items.push(formatItem(searchStr.substr(0, nextIndex)));
                 cursor += nextIndex + 1;
+            } else {
+                cursor = null;
             }
-        } else if (ROW_DELIMITER.test(nextChar)) {
-            items.push(formatItem(searchStr.substr(0, nextIndex)));
-            cursor += nextIndex;
-        } else if (!hasMoreData) {
-            items.push(formatItem(searchStr.substr(0, nextIndex)));
-            cursor += nextIndex + 1;
-        } else {
-            cursor = null;
         }
 
-        return cursor;
+        return {
+            cursor: cursor,
+            corrupt: corrupt
+        };
     }
 
     function getNextToken(line, cursor) {
@@ -142,6 +157,22 @@ function createParser(options) {
 
     return function parseLine(line, hasMoreData) {
         var i = 0, l = line.length, rows = [], items = [], token, nextToken, cursor, lastLineI = 0;
+        
+        var parseComment = function() {
+            cursor = parseCommentLine(line, i, hasMoreData);
+            if (cursor === null) {
+                i = lastLineI;
+                return true;
+            } else if (cursor < l) {
+                lastLineI = i = cursor;
+                return false;
+            }
+            
+            i = cursor;
+            cursor = null;
+            return true;
+        }
+        
         while (i < l) {
             nextToken = getNextToken(line, i);
             token = nextToken.token;
@@ -158,28 +189,25 @@ function createParser(options) {
                     break;
                 }
             } else if (hasComments && token === COMMENT) {
-                cursor = parseCommentLine(line, i, hasMoreData);
-                if (cursor === null) {
-                    i = lastLineI;
-                    break;
-                } else if (cursor < l) {
-                    lastLineI = i = cursor;
-                } else {
-                    i = cursor;
-                    cursor = null;
-                    break;
-                }
+                if (parseComment()) break;
             } else {
+                var ret;
                 if (token === ESCAPE) {
-                    cursor = parseEscapedItem(line, items, nextToken.cursor, hasMoreData);
+                    ret = parseEscapedItem(line, items, nextToken.cursor, hasMoreData);
                 } else {
-                    cursor = parseItem(line, items, i, hasMoreData);
+                    ret = parseItem(line, items, i, hasMoreData);
                 }
-                if (cursor === null) {
+
+                if (ret.corrupt) {
+                    items = [];
+                    // treat whole line as comment
+                    if (parseComment()) break;
+                } else if (ret.cursor === null) {
+                    cursor = null;
                     i = lastLineI;
                     break;
                 } else {
-                    i = cursor;
+                    i = cursor = ret.cursor;
                 }
             }
 

--- a/test/assets/test26.csv
+++ b/test/assets/test26.csv
@@ -1,0 +1,11 @@
+first_name,last_name,email_address,address
+First1,Last1,email1@email.com,"1 Street St, State ST, 88888"
+First2,Last2,email2@email.com,"2 Street St, State ST, 88888"
+First3,Last3,email3@email.com,"3 Street St, State ST, 88888"
+Fir","asjkldsajldsjla
+First4,Last4,email4@email.com,"4 Street St, State ST, 88888"
+First5,Last5,email5@email.com,"5 Street St, State ST, 88888"
+First6,Last6,email6@email.com,"6 Street St, State ST, 88888"
+First7,Last7,email7@email.com,"7 Street St, State ST, 88888"
+First8,Last8,email8@email.com,"8 Street St, State ST, 88888"
+First9,Last9,email9@email.com,"9 Street St, State ST, 88888"

--- a/test/parsing.test.js
+++ b/test/parsing.test.js
@@ -1187,4 +1187,23 @@ it.describe("fast-csv parsing", function (it) {
         });
     });
 
+    it.should("handle parsing errors if parseErrorHandler is set", function (next) {
+        var actual = [], errors = [];
+        csv
+            .fromPath(path.resolve(__dirname, "./assets/test26.csv"), {
+                headers: true,
+                handleError: function(err) {
+                    errors.push(err);
+                }
+            })
+            .on("data", function (data) {
+                actual.push(data);
+            }).
+            on("end", function (count) {
+                assert.deepEqual(actual, expected1);
+                assert.equal(count, actual.length);
+                assert.equal(1, errors.length);
+                next();
+            });
+    });
 });


### PR DESCRIPTION
When loading large CSV files such as web log, sometimes it may contain corrupted lines. This checkin is to enable the parsing process to skip corrupted lines and continue.