### PR TITLE
problem with utf8 encoded streams that have multi-byte characters

### DIFF
--- a/lib/parser/parser_stream.js
+++ b/lib/parser/parser_stream.js
@@ -8,6 +8,7 @@ var extended = require("../extended"),
     DEFAULT_DELIMITER = ",",
     createParser = require("./parser"),
     fs = require("fs"),
+    StringDecoder = require('string_decoder').StringDecoder,
     hasIsPaused = !!stream.Transform.prototype.isPaused;
 
 function ParserStream(options) {
@@ -15,6 +16,7 @@ function ParserStream(options) {
     options.objectMode = extended.has(options, "objectMode") ? options.objectMode : true;
     stream.Transform.call(this, options);
     this.lines = "";
+    this.decoder = new StringDecoder();
     this._parsedHeaders = false;
     this._rowCount = -1;
     this._emitData = false;
@@ -192,7 +194,7 @@ extended(ParserStream).extend({
 
     _transform: function (data, encoding, done) {
         var lines = this.lines,
-            lineData = (lines + data),
+            lineData = (lines + this.decoder.write(data)),
             self = this;
         if (lineData.length > 1) {
             this._parse(lineData, true, function (err, lineData) {


### PR DESCRIPTION
# Problem

When piping a utf-8 encoding file with multi-byte characters (such as German Umlaut öäü ...) to the parser, it can happen, that the the chunks of the stream are split within a multi-byte character.
The current implementation simply concatenates the strings which can lead to Unicode Character 'REPLACEMENT CHARACTER' (U+FFFD), when the two chunks of the stream split a multi-byte character into two parts.
b1 = new Buffer([0xc3,0xa4,0xc3])
b2 = new Buffer([0xb6])
b1 + b2 
=> 'ä��'
vs.
b1 = new Buffer([0xc3,0xa4])
b2 = new Buffer([0xc3,0xb6])
b1 + b2 
=> 'äö'

# Solution

use string_decoder (https://nodejs.org/api/string_decoder.html) to correctly decode the chunks.