### PR TITLE
Allow passing sparse array of headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a library that provides CSV parsing and formatting.
 All methods accept the following `options`
 
 * `objectMode=true`: Ensure that `data` events have an object emitted rather than the stringified version set to false to have a stringified buffer.
-* `headers=false`: Set to true if you expect the first line of your `CSV` to contain headers, alternatly you can specify an array of headers to use.
+* `headers=false`: Set to true if you expect the first line of your `CSV` to contain headers, alternatly you can specify an array of headers to use. You can also specify a sparse array to omit some of the columns.
 * `ignoreEmpty=false`: If you wish to ignore empty rows.
 * `discardUnmappedColumns=false`: If you want to discard columns that do not map to a header.
 * `strictColumnHandling=false`: If you want to consider empty lines/lines with too few fields as errors - Only to be used with `headers=true`
@@ -188,6 +188,22 @@ var stream = fs.createReadStream("my.csv");
 
 csv
  .fromStream(stream, {headers : ["firstName", "lastName", "address"]})
+ .on("data", function(data){
+     console.log(data);
+ })
+ .on("end", function(){
+     console.log("done");
+ });
+
+```
+
+To omit some of the data columns you may not need, pass a sparse array as `headers`.
+
+```javascript
+var stream = fs.createReadStream("my.csv");
+
+csv
+ .fromStream(stream, {headers : ["firstName" , , "address"]})
  .on("data", function(data){
      console.log(data);
  })

--- a/lib/parser/parser_stream.js
+++ b/lib/parser/parser_stream.js
@@ -139,6 +139,9 @@ extended(ParserStream).extend({
                         return orig(null, cb);
                     }
                     while (++i < headersLength) {
+                        if (isUndefined(headers[i])) {
+                          continue;
+                        }
                         val = data[i];
                         ret[headers[i]] = isUndefined(val) ? '' : val;
                     }

--- a/test/parsing.test.js
+++ b/test/parsing.test.js
@@ -68,6 +68,45 @@ var expected1 = [
     }
 ];
 
+var expected1_sparse = [
+    {
+        "first_name": "First1",
+        "email_address": "email1@email.com",
+    },
+    {
+        "first_name": "First2",
+        "email_address": "email2@email.com",
+    },
+    {
+        "first_name": "First3",
+        "email_address": "email3@email.com",
+    },
+    {
+        "first_name": "First4",
+        "email_address": "email4@email.com",
+    },
+    {
+        "first_name": "First5",
+        "email_address": "email5@email.com",
+    },
+    {
+        "first_name": "First6",
+        "email_address": "email6@email.com",
+    },
+    {
+        "first_name": "First7",
+        "email_address": "email7@email.com",
+    },
+    {
+        "first_name": "First8",
+        "email_address": "email8@email.com",
+    },
+    {
+        "first_name": "First9",
+        "email_address": "email9@email.com",
+    }
+];
+
 var expected2 = [
     ['First1', 'Last1', 'email1@email.com', '1 Street St, State ST, 88888'],
     ['First2', 'Last2', 'email2@email.com', '2 Street St, State ST, 88888'],
@@ -542,6 +581,21 @@ it.describe("fast-csv parsing", function (it) {
             .on("error", next)
             .on("end", function (count) {
                 assert.deepEqual(actual, expected1);
+                assert.equal(count, actual.length);
+                next();
+            });
+    });
+
+    it.should("allow specifying of columns as a sparse array", function (next) {
+        var actual = [];
+        csv
+            .fromPath(path.resolve(__dirname, "./assets/test2.csv"), {headers: ["first_name" , , "email_address" , , ]})
+            .on("data", function (data, index) {
+                actual.push(data);
+            })
+            .on("error", next)
+            .on("end", function (count) {
+                assert.deepEqual(actual, expected1_sparse);
                 assert.equal(count, actual.length);
                 next();
             });


### PR DESCRIPTION
Passing sparse array as `headers` can help to skip some of the columns while parsing:

```
First1 , Last1 , email1@email.com , "1 Street St, State ST, 88888"
First2 , Last2 , email2@email.com , "2 Street St, State ST, 88888"
```

If we only need a name and an e-mail, we could pass such array as `headers`:

```js
{ headers: ["first_name" , , "email_address" , , ] }
```

```json
{
    "first_name": "First1",
    "email_address": "email1@email.com"
},
{
    "first_name": "First2",
    "email_address": "email2@email.com"
}
```