### PR TITLE
another fix for issue #111 last cell has only spaces

### DIFF
--- a/lib/parser/parser.js
+++ b/lib/parser/parser.js
@@ -17,6 +17,7 @@ function createParser(options) {
         ESCAPE_CHAR = options.escape || '"',
         NEXT_TOKEN_REGEXP = new RegExp("([^\\s]|\\r\\n|\\n|\\r|" + delimiter + ")"),
         ROW_DELIMITER = /(\r\n|\n|\r)/,
+        SPACE_CHAR_REGEX = new RegExp("(?!" + delimiter + ") "),
         COMMENT, hasComments;
     if (has(options, "comment")) {
         COMMENT = options.comment;
@@ -117,9 +118,15 @@ function createParser(options) {
             } else {
                 items.push(formatItem(searchStr.substr(0, nextIndex)));
                 cursor += nextIndex + 1;
-                // if ends with a comma, append an empty element, unless strict column handling
-                if (!options.strictColumnHandling && (ROW_DELIMITER.test(line.charAt(cursor)) || cursor >= line.length)) { 
+
+                var cursorChar = line.charAt(cursor);
+                // if ends with a delimiter, append an empty element, unless strict column handling
+                if (!options.strictColumnHandling && (ROW_DELIMITER.test(cursorChar) || cursor >= line.length)) {
                     items.push('');
+                }
+                // if ends with empty space that is not a delimiter, append an empty space, unless strict column handling
+                if (!options.strictColumnHandling && SPACE_CHAR_REGEX.test(cursorChar)) {
+                    items.push(cursorChar);
                 }
             }
         } else if (ROW_DELIMITER.test(nextChar)) {

--- a/test/issues.test.js
+++ b/test/issues.test.js
@@ -206,5 +206,37 @@ it.describe("github issues", function (it) {
 			});
         });
 
+        it.should("parse a block of CSV text with a trailing delimiter followed by a space", function() {
+            var data = "first_name,last_name,email_address,empty\nFirst1,Last1,email1@email.com, \n";
+            var myParser = parser({ delimiter: "," });
+            assert.deepEqual(myParser(data, false), {
+                "line": "", "rows": [
+                    ["first_name", "last_name", "email_address", "empty"],
+                    ["First1", "Last1", "email1@email.com", " "]
+                ]
+            });
+        });
+
+        it.should("parse a block of Space Separated Value text with a trailing delimiter", function() {
+            var data = "first_name last_name email_address empty\nFirst1 Last1 email1@email.com \n";
+            var myParser = parser({ delimiter: " " });
+            assert.deepEqual(myParser(data, false), {
+                "line": "", "rows": [
+                    ["first_name", "last_name", "email_address", "empty"],
+                    ["First1", "Last1", "email1@email.com", ""]
+                ]
+            });
+                });
+
+        it.should("parse a block of Space Separated Values with two delimiters at file end", function() {
+            var data = "first_name last_name email_address empty empty2\nFirst1 Last1 email1@email.com  \n";
+            var myParser = parser({ delimiter: " " });
+            assert.deepEqual(myParser(data, false), {
+                "line": "", "rows": [
+                    ["first_name", "last_name", "email_address", "empty", "empty2"],
+                    ["First1", "Last1", "email1@email.com", "", ""]
+                ]
+            });
+        });
     });
 });

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -30,6 +30,28 @@ it.describe("fast-csv parser", function (it) {
                 });
             });
 
+            it.should("parse a block of CSV text with a trailing delimiter followed by a space", function() {
+                var data = "first_name,last_name,email_address,empty\nFirst1,Last1,email1@email.com, \n";
+                var myParser = parser({ delimiter: "," });
+                assert.deepEqual(myParser(data, false), {
+                    "line": "", "rows": [
+                        ["first_name", "last_name", "email_address", "empty"],
+                        ["First1", "Last1", "email1@email.com", " "]
+                    ]
+                });
+            });
+
+            it.should("parse a block of Space Separated Value text with a trailing delimiter", function() {
+                var data = "first_name last_name email_address empty\nFirst1 Last1 email1@email.com \n";
+                var myParser = parser({ delimiter: " " });
+                assert.deepEqual(myParser(data, false), {
+                    "line": "", "rows": [
+                        ["first_name", "last_name", "email_address", "empty"],
+                        ["First1", "Last1", "email1@email.com", ""]
+                    ]
+                });
+            });
+
             it.should("return the rest of the line if there is more data", function () {
                 var data = "first_name,last_name,email_address\nFirst1,Last1,email1@email.com";
                 var myParser = parser({delimiter: ","});
@@ -119,6 +141,28 @@ it.describe("fast-csv parser", function (it) {
             it.should("parse a block of CSV text with a trailing delimiter", function () {
                 var data = "first_name,last_name,email_address,empty\nFirst1,Last1,email1@email.com,\n";
                 var myParser = parser({delimiter: ","});
+                assert.deepEqual(myParser(data, false), {
+                    "line": "", "rows": [
+                        ["first_name", "last_name", "email_address", "empty"],
+                        ["First1", "Last1", "email1@email.com", ""]
+                    ]
+                });
+            });
+
+            it.should("parse a block of CSV text with a trailing delimiter followed by a space", function() {
+                var data = "first_name,last_name,email_address,empty\nFirst1,Last1,email1@email.com, \n";
+                var myParser = parser({ delimiter: "," });
+                assert.deepEqual(myParser(data, false), {
+                    "line": "", "rows": [
+                        ["first_name", "last_name", "email_address", "empty"],
+                        ["First1", "Last1", "email1@email.com", " "]
+                    ]
+                });
+            });
+
+            it.should("parse a block of Space Separated Value text with a trailing delimiter", function() {
+                var data = "first_name last_name email_address empty\nFirst1 Last1 email1@email.com \n";
+                var myParser = parser({ delimiter: " " });
                 assert.deepEqual(myParser(data, false), {
                     "line": "", "rows": [
                         ["first_name", "last_name", "email_address", "empty"],
@@ -277,6 +321,28 @@ it.describe("fast-csv parser", function (it) {
             it.should("parse a block of CSV text with a trailing delimiter", function () {
                 var data = "first_name,last_name,email_address,empty\nFirst1,Last1,email1@email.com,\n";
                 var myParser = parser({delimiter: ","});
+                assert.deepEqual(myParser(data, false), {
+                    "line": "", "rows": [
+                        ["first_name", "last_name", "email_address", "empty"],
+                        ["First1", "Last1", "email1@email.com", ""]
+                    ]
+                });
+            });
+
+            it.should("parse a block of CSV text with a trailing delimiter followed by a space", function() {
+                var data = "first_name,last_name,email_address,empty\nFirst1,Last1,email1@email.com, \n";
+                var myParser = parser({ delimiter: "," });
+                assert.deepEqual(myParser(data, false), {
+                    "line": "", "rows": [
+                        ["first_name", "last_name", "email_address", "empty"],
+                        ["First1", "Last1", "email1@email.com", " "]
+                    ]
+                });
+            });
+
+            it.should("parse a block of Space Separated Value text with a trailing delimiter", function() {
+                var data = "first_name last_name email_address empty\nFirst1 Last1 email1@email.com \n";
+                var myParser = parser({ delimiter: " " });
                 assert.deepEqual(myParser(data, false), {
                     "line": "", "rows": [
                         ["first_name", "last_name", "email_address", "empty"],


### PR DESCRIPTION
Built on top of @rickwargo's [pull request](https://github.com/C2FO/fast-csv/pull/137) to fix another case with issue #111  
* added a cell with a space when the line ends with: `,` ` `
* added tests for ending space in **test/issues.test.js**
* added tests for ending space in **parser.test.js**
* added tests in both **test/issues.test.js** and **parser.test.js** to ensure that Space Separated Value parsing is not affected in this case.