### PR TITLE
Fix and test cases for Issue #144: fast-csv inserts columns when parsing CSVs with only spaces for field values

### DIFF
--- a/lib/parser/parser.js
+++ b/lib/parser/parser.js
@@ -125,7 +125,7 @@ function createParser(options) {
                     items.push('');
                 }
                 // if ends with empty space that is not a delimiter, append an empty space, unless strict column handling
-                if (!options.strictColumnHandling && SPACE_CHAR_REGEX.test(cursorChar)) {
+                if (!options.strictColumnHandling && SPACE_CHAR_REGEX.test(cursorChar) && !hasMoreData) {
                     items.push(cursorChar);
                 }
             }

--- a/test/assets/test26.csv
+++ b/test/assets/test26.csv
@@ -1,0 +1,2 @@
+Model	Last_Change_Date	Region	Make	Aircraft_Group	Regis_Code	Design_Character	No_Engines	Type_Engine	Type_Landing_Gear	TC_Data_Sheet_Number	TC_Model
+058B        	09/09/2003	GL	ARONCA	58    	0191006	1H7	1          	  	  	A751    	AERONCA058B         

--- a/test/assets/test27.csv
+++ b/test/assets/test27.csv
@@ -1,0 +1,2 @@
+Model,Last_Change_Date,Region,Make,Aircraft_Group,Regis_Code,Design_Character,No_Engines,Type_Engine,Type_Landing_Gear,TC_Data_Sheet_Number,TC_Model
+058B        ,09/09/2003,GL,ARONCA,58    ,0191006,1H7,1          ,  ,  ,A751    ,AERONCA058B         

--- a/test/parsing.test.js
+++ b/test/parsing.test.js
@@ -421,6 +421,25 @@ var expected25 = [
 
 var expected25_invalid = [ 'First2', 'Last2', 'email2@email.com' ];
 
+var expected26 = [
+    {
+        "Model" : "058B",
+        "Last_Change_Date" : "09/09/2003",
+        "Region" : "GL",
+        "Make" : "ARONCA",
+        "Aircraft_Group" : "58",
+        "Regis_Code" : "0191006",
+        "Design_Character" : "1H7",
+        "No_Engines" : "1",
+        "Type_Engine" : "",
+        "Type_Landing_Gear" : "",
+        "TC_Data_Sheet_Number" : "A751",
+        "TC_Model": "AERONCA058B"
+    }
+];
+
+var expected27 = expected26;
+
 it.describe("fast-csv parsing", function (it) {
 
     it.timeout(60000);
@@ -1239,6 +1258,34 @@ it.describe("fast-csv parsing", function (it) {
         assert.throws(function () {
             csv({headers: true}).fromPath(path.resolve(__dirname, "./assets/test7.csv")).transform("hello");
         });
+    });
+
+    it.should("handle tab delimited CSVs with only spaces for field values", function (next) {
+        var actual = [];
+        csv
+            .fromPath(path.resolve(__dirname, "./assets/test26.csv"), {headers: true, delimiter: '\t', trim: true})
+            .on("data", function (data) {
+                actual.push(data);
+            }).
+            on("end", function (count) {
+                assert.deepEqual(actual, expected26);
+                assert.equal(count, actual.length);
+                next();
+            });
+    });
+
+    it.should("handle CSVs with only spaces for field values", function (next) {
+        var actual = [];
+        csv
+            .fromPath(path.resolve(__dirname, "./assets/test27.csv"), {headers: true, trim: true})
+            .on("data", function (data) {
+                actual.push(data);
+            }).
+            on("end", function (count) {
+                assert.deepEqual(actual, expected27);
+                assert.equal(count, actual.length);
+                next();
+            });
     });
 
 });


### PR DESCRIPTION
Small fix to allow CSV columns to contain only spaces.  Submitted two test cases with different delimiters because the original problem was found with tab delimiters.  All 'grunt it' tests pass.