### PR TITLE
Handle split CRLF

### DIFF
--- a/lib/parser/parser.js
+++ b/lib/parser/parser.js
@@ -143,10 +143,11 @@ function createParser(options) {
     }
 
     function getNextToken(line, cursor) {
-        var token, nextIndex, subStr = line.substr(cursor);
+        var token, tokenLen, nextIndex, subStr = line.substr(cursor);
         if ((nextIndex = subStr.search(NEXT_TOKEN_REGEXP)) !== -1) {
-            token = line[cursor += nextIndex];
-            cursor += subStr.match(NEXT_TOKEN_REGEXP)[1].length - 1;
+            tokenLen = subStr.match(NEXT_TOKEN_REGEXP)[1].length;
+            token = line.substr(cursor + nextIndex, tokenLen);
+            cursor += nextIndex + tokenLen - 1;
         }
         return {token: token, cursor: cursor};
     }
@@ -167,6 +168,11 @@ function createParser(options) {
                     items = [];
                     lastLineI = i;
                 } else {
+                    // if ends with CR and there is more data, keep unparsed due to possible coming LF in CRLF
+                    if (token === '\r' && hasMoreData) {
+                        i = lastLineI;
+                        cursor = null;
+                    }
                     break;
                 }
             } else if (hasComments && token === COMMENT) {

--- a/test/issues.test.js
+++ b/test/issues.test.js
@@ -239,4 +239,16 @@ it.describe("github issues", function (it) {
             });
         });
     });
+
+    it.skip("#150", function (it) {
+        it.should("not parse a row if a new line is ambiguous and there is more data", function () {
+            var data = "first_name,last_name,email_address\r";
+            var myParser = parser({delimiter: ","});
+            var parsedData = myParser(data, true);
+            assert.deepEqual(parsedData, {
+                "line": "first_name,last_name,email_address\r",
+                "rows": []
+            });
+        });
+    });
 });

--- a/test/issues.test.js
+++ b/test/issues.test.js
@@ -240,7 +240,7 @@ it.describe("github issues", function (it) {
         });
     });
 
-    it.skip("#150", function (it) {
+    it.describe("#150", function (it) {
         it.should("not parse a row if a new line is ambiguous and there is more data", function () {
             var data = "first_name,last_name,email_address\r";
             var myParser = parser({delimiter: ","});

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -319,7 +319,7 @@ it.describe("fast-csv parser", function (it) {
             });
 
             it.should("parse a block of CSV text with a trailing delimiter", function () {
-                var data = "first_name,last_name,email_address,empty\nFirst1,Last1,email1@email.com,\n";
+                var data = "first_name,last_name,email_address,empty\rFirst1,Last1,email1@email.com,\r";
                 var myParser = parser({delimiter: ","});
                 assert.deepEqual(myParser(data, false), {
                     "line": "", "rows": [
@@ -330,7 +330,7 @@ it.describe("fast-csv parser", function (it) {
             });
 
             it.should("parse a block of CSV text with a trailing delimiter followed by a space", function() {
-                var data = "first_name,last_name,email_address,empty\nFirst1,Last1,email1@email.com, \n";
+                var data = "first_name,last_name,email_address,empty\nFirst1,Last1,email1@email.com, \r";
                 var myParser = parser({ delimiter: "," });
                 assert.deepEqual(myParser(data, false), {
                     "line": "", "rows": [
@@ -341,7 +341,7 @@ it.describe("fast-csv parser", function (it) {
             });
 
             it.should("parse a block of Space Separated Value text with a trailing delimiter", function() {
-                var data = "first_name last_name email_address empty\nFirst1 Last1 email1@email.com \n";
+                var data = "first_name last_name email_address empty\rFirst1 Last1 email1@email.com \r";
                 var myParser = parser({ delimiter: " " });
                 assert.deepEqual(myParser(data, false), {
                     "line": "", "rows": [
@@ -610,6 +610,16 @@ it.describe("fast-csv parser", function (it) {
                 var parsedData = myParser(data, true);
                 assert.deepEqual(parsedData, {
                     "line": "first_name,last_name,email_address",
+                    "rows": []
+                });
+            });
+
+            it.skip("not parse a row if a new line is incomplete and there is more data", function () {
+                var data = "first_name,last_name,email_address\r";
+                var myParser = parser({delimiter: ","});
+                var parsedData = myParser(data, true);
+                assert.deepEqual(parsedData, {
+                    "line": "first_name,last_name,email_address\r",
                     "rows": []
                 });
             });

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -400,7 +400,7 @@ it.describe("fast-csv parser", function (it) {
                 });
             });
 
-            it.skip("not parse a row if an ambiguous new line is found and there is more data", function () {
+            it.should("not parse a row if an ambiguous new line is found and there is more data", function () {
                 var data = "first_name,last_name,email_address\r";
                 var myParser = parser({delimiter: ","});
                 var parsedData = myParser(data, true);
@@ -530,7 +530,7 @@ it.describe("fast-csv parser", function (it) {
                 });
             });
 
-            it.skip("not parse a row if an ambiguous new line is found and there is more data", function () {
+            it.should("not parse a row if an ambiguous new line is found and there is more data", function () {
                 var data = '"first_name","last_name","email_address"\r';
                 var myParser = parser({delimiter: ","});
                 var parsedData = myParser(data, true);
@@ -610,7 +610,7 @@ it.describe("fast-csv parser", function (it) {
                 });
             });
 
-            it.skip("not parse a row if a new line is incomplete and there is more data", function () {
+            it.should("not parse a row if a new line is incomplete and there is more data", function () {
                 var data = "first_name,last_name,email_address\r";
                 var myParser = parser({delimiter: ","});
                 var parsedData = myParser(data, true);

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -400,15 +400,13 @@ it.describe("fast-csv parser", function (it) {
                 });
             });
 
-            it.should("parse a row if a new line is found and there is more data", function () {
+            it.skip("not parse a row if an ambiguous new line is found and there is more data", function () {
                 var data = "first_name,last_name,email_address\r";
                 var myParser = parser({delimiter: ","});
                 var parsedData = myParser(data, true);
                 assert.deepEqual(parsedData, {
-                    "line": "",
-                    "rows": [
-                        ["first_name", "last_name", "email_address"]
-                    ]
+                    "line": "first_name,last_name,email_address\r",
+                    "rows": []
                 });
             });
 
@@ -532,15 +530,13 @@ it.describe("fast-csv parser", function (it) {
                 });
             });
 
-            it.should("parse a row if a new line is found and there is more data", function () {
+            it.skip("not parse a row if an ambiguous new line is found and there is more data", function () {
                 var data = '"first_name","last_name","email_address"\r';
                 var myParser = parser({delimiter: ","});
                 var parsedData = myParser(data, true);
                 assert.deepEqual(parsedData, {
-                    "line": "",
-                    "rows": [
-                        ["first_name", "last_name", "email_address"]
-                    ]
+                    "line": '"first_name","last_name","email_address"\r',
+                    "rows": []
                 });
             });
         });


### PR DESCRIPTION
Modify the parser's end of the buffer handling by keeping the line unparsed if the last token is `\r` and there is more data. 

As a result, if the `\r\n` token is split in half between two buffers it will be joined together in the processing of the second buffer.

This solution is fully backward compatible and much simpler than auto-detection of a row delimiter, which also might be not fully backward compatible. 

Fixes issues #150, #146