### PR TITLE
skip trailing whitespace after a quoted field

### DIFF
--- a/lib/parser/parser.js
+++ b/lib/parser/parser.js
@@ -68,7 +68,7 @@ function createParser(options) {
             if (hasMoreData && (next.cursor + 1) >= l) {
                 cursor = null;
             } else {
-                cursor++;
+                cursor = next.cursor + 1;
             }
         } else if (depth && !nextToken) {
             if (hasMoreData) {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -256,6 +256,17 @@ it.describe("fast-csv parser", function (it) {
                 });
             });
 
+            it.should("skip trailing spaces after a quoted value", function () {
+                var data = 'first_name,last_name,email_address\n"First,1"  ,"Last,1" ,"email1@email.com"';
+                var myParser = parser({delimiter: ","});
+                assert.deepEqual(myParser(data, false), {
+                    "line": "", "rows": [
+                        ["first_name", "last_name", "email_address"],
+                        ["First,1", "Last,1", "email1@email.com"]
+                    ]
+                });
+			});
+
             it.should("not parse a row if a new line is not found and there is more data", function () {
                 var data = '"first_name","last_name","email_address"';
                 var myParser = parser({delimiter: ","});
@@ -510,6 +521,17 @@ it.describe("fast-csv parser", function (it) {
                 });
             });
 
+            it.should("skip trailing spaces after a quoted value", function () {
+                var data = 'first_name,last_name,email_address\r"First,1"  ,"Last,1" ,"email1@email.com"';
+                var myParser = parser({delimiter: ","});
+                assert.deepEqual(myParser(data, false), {
+                    "line": "", "rows": [
+                        ["first_name", "last_name", "email_address"],
+                        ["First,1", "Last,1", "email1@email.com"]
+                    ]
+                });
+			});
+
             it.should("not parse a row if a new line is not found and there is more data", function () {
                 var data = '"first_name","last_name","email_address"';
                 var myParser = parser({delimiter: ","});
@@ -741,6 +763,17 @@ it.describe("fast-csv parser", function (it) {
                     ]
                 });
             });
+
+            it.should("skip trailing spaces after a quoted value", function () {
+                var data = 'first_name,last_name,email_address\r\n"First,1"  ,"Last,1" ,"email1@email.com"';
+                var myParser = parser({delimiter: ","});
+                assert.deepEqual(myParser(data, false), {
+                    "line": "", "rows": [
+                        ["first_name", "last_name", "email_address"],
+                        ["First,1", "Last,1", "email1@email.com"]
+                    ]
+                });
+			});
 
             it.should("not parse a row if a new line is not found and there is more data", function () {
                 var data = '"first_name","last_name","email_address"';


### PR DESCRIPTION
fix for files that use spaces for alignment like:
```
"ABC"   ,"DEFG"  ,12345,"HI"  
"JKLM"  ,"NOP"   ,67890,"QR"  
```

Uses the next token lookup to move the cursor after the spaces to continue

Added tests, and doesn't break existing tests