### PR TITLE
Cloning the option object to avoid issues on object reuse

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,8 @@ module.exports = function (grunt) {
         jshint: {
             file: "./lib/*.js",
             options: {
-                jshintrc: '.jshintrc'
+                jshintrc: '.jshintrc',
+                reporterOutput:""
             }
         },
 

--- a/lib/parser/parser_stream.js
+++ b/lib/parser/parser_stream.js
@@ -11,8 +11,8 @@ var extended = require("../extended"),
     StringDecoder = require('string_decoder').StringDecoder,
     hasIsPaused = !!stream.Transform.prototype.isPaused;
 
-function ParserStream(options) {
-    options = options || {};
+function ParserStream(baseOptions) {
+    var options = baseOptions ? extended.deepMerge({}, baseOptions) : {};
     options.objectMode = extended.has(options, "objectMode") ? options.objectMode : true;
     stream.Transform.call(this, options);
     this.lines = "";
@@ -23,7 +23,10 @@ function ParserStream(options) {
     var delimiter;
     if (extended.has(options, "delimiter")) {
         delimiter = options.delimiter;
-        if (delimiter.length > 1) {
+        if (!extended.isString(delimiter)) {
+            throw new Error("delimiter option shoulld be a string");
+        }
+        if (delimiter !== null && delimiter.length > 1) {
             throw new Error("delimiter option must be one character long");
         }
         delimiter = extended.escape(delimiter);

--- a/test/assets/issue252.1.csv
+++ b/test/assets/issue252.1.csv
@@ -1,0 +1,2 @@
+first_name|last_name|email_address|address
+azer|tez|azer@azrt.com|aaz eez

--- a/test/assets/issue252.2.csv
+++ b/test/assets/issue252.2.csv
@@ -1,0 +1,2 @@
+first_name|last_name|email_address|address
+azer|tez|azer@azrt.com|aaz eez

--- a/test/issues.test.js
+++ b/test/issues.test.js
@@ -300,4 +300,32 @@ it.describe("github issues", function (it) {
               });
         });
     });
+
+    it.describe("#227", function (it) {
+
+        it.should("allow consecutive parsing with the same options", function (next) {
+            var options = {
+                delimiter: '|'
+            };
+            csv
+                .fromPath(path.resolve(__dirname, "./assets/issue252.1.csv"), options)
+                .on('data', function () {})
+                .on('end', function () {
+                    csv
+                      .fromPath(path.resolve(__dirname, "./assets/issue252.2.csv"), options)
+                      .on("data", function () {})
+                      .on("error", function () {
+                          next("Should not get here!");
+                      })
+                      .on("end", function() {
+                          next();
+                      });
+                })
+                .on("error", function () {
+                    next("Should not get here!");
+                })
+           
+        })
+    })
+
 });


### PR DESCRIPTION
#227 

This allows reuse of the same object for options as it isn't modified anymore.

deepMerge was used as cloning function since JSON.parse(JSON.stringify()) doesn't handle sparse arrays correctly.

Some checks were added to please the linter.