### PR TITLE
Safe buffer initilization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
   - "4"
   - "5"
+  - "6"
+  - "8"
+  - "10"
   - "stable"
 before_script:
   - npm install -g grunt-cli

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,8 @@ module.exports = function (grunt) {
         jshint: {
             file: "./lib/*.js",
             options: {
-                jshintrc: '.jshintrc'
+                jshintrc: '.jshintrc',
+                reporterOutput: '',
             }
         },
 

--- a/lib/formatter/formatter.js
+++ b/lib/formatter/formatter.js
@@ -1,5 +1,6 @@
 var fs = require("fs"),
     extended = require("../extended"),
+    Buffer = require('safer-buffer').Buffer,
     has = extended.has,
     isBoolean = extended.isBoolean,
     isUndefinedOrNull = extended.isUndefinedOrNull,
@@ -129,7 +130,7 @@ function checkHeaders(stream, item) {
     }
     if (!stream.hasWrittenHeaders) {
         stream.totalCount++;
-        stream.push(new Buffer(stream.formatter(stream.headers, true), "utf8"));
+        stream.push(Buffer.from(stream.formatter(stream.headers, true), "utf8"));
         stream.hasWrittenHeaders = true;
         ret = isHashArray(item) || !isArray(item);
     }

--- a/lib/formatter/formatter_stream.js
+++ b/lib/formatter/formatter_stream.js
@@ -1,6 +1,7 @@
 var fs = require("fs"),
     util = require("util"),
     extended = require("../extended"),
+    Buffer = require('safer-buffer').Buffer,
     escape = extended.escape,
     isArray = extended.isArray,
     has = extended.has,
@@ -59,7 +60,7 @@ extended(CsvTransformStream).extend({
                 cb(err);
             } else {
                 if (checkHeaders(self, item)) {
-                    self.push(new Buffer(transformItem(self, item), "utf8"));
+                    self.push(Buffer.from(transformItem(self, item), "utf8"));
                 }
                 cb();
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,678 @@
+{
+    "name": "fast-csv",
+    "version": "1.1.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "dev": true
+        },
+        "argparse": {
+            "version": "0.1.16",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+            "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+            "dev": true,
+            "requires": {
+                "underscore": "~1.7.0",
+                "underscore.string": "~2.4.0"
+            },
+            "dependencies": {
+                "underscore.string": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                    "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+                    "dev": true
+                }
+            }
+        },
+        "arguments-extended": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/arguments-extended/-/arguments-extended-0.0.3.tgz",
+            "integrity": "sha1-YQfkkX0OtvCk3WYyD8Fa/HLvSUY=",
+            "requires": {
+                "extended": "~0.0.3",
+                "is-extended": "~0.0.8"
+            }
+        },
+        "array-extended": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/array-extended/-/array-extended-0.0.11.tgz",
+            "integrity": "sha1-1xRK50jek8pybxIQCdv/FibRZL0=",
+            "requires": {
+                "arguments-extended": "~0.0.3",
+                "extended": "~0.0.3",
+                "is-extended": "~0.0.3"
+            }
+        },
+        "async": {
+            "version": "0.1.22",
+            "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+            "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+            "dev": true
+        },
+        "cli": {
+            "version": "0.6.6",
+            "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+            "integrity": "sha1-Aq1Eo4Cr8nraxebwzdewQ9dMU+M=",
+            "dev": true,
+            "requires": {
+                "exit": "0.1.2",
+                "glob": "~ 3.2.1"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "3.2.11",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                    "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2",
+                        "minimatch": "0.3"
+                    }
+                },
+                "minimatch": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                    "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
+                    }
+                }
+            }
+        },
+        "coffee-script": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+            "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+            "dev": true
+        },
+        "colors": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+            "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+            "dev": true
+        },
+        "commander": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
+            "integrity": "sha1-UNFlGGiuYOzP8KLZ80WVN2vGsEE=",
+            "dev": true,
+            "requires": {
+                "keypress": "0.1.x"
+            }
+        },
+        "console-browserify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+            "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+            "dev": true,
+            "requires": {
+                "date-now": "^0.1.4"
+            }
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "date-extended": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/date-extended/-/date-extended-0.0.6.tgz",
+            "integrity": "sha1-I4AtV90b94GIE/4MMuhRqG2iZ8k=",
+            "requires": {
+                "array-extended": "~0.0.3",
+                "extended": "~0.0.3",
+                "is-extended": "~0.0.3"
+            }
+        },
+        "date-now": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+            "dev": true
+        },
+        "dateformat": {
+            "version": "1.0.2-1.2.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+            "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+            "dev": true
+        },
+        "declare.js": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/declare.js/-/declare.js-0.0.8.tgz",
+            "integrity": "sha1-BHit/5VkwAT1Hfc9i8E0AZ0o3N4="
+        },
+        "dom-serializer": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+            "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+            "dev": true,
+            "requires": {
+                "domelementtype": "^1.3.0",
+                "entities": "^1.1.1"
+            },
+            "dependencies": {
+                "entities": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+                    "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+                    "dev": true
+                }
+            }
+        },
+        "domelementtype": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+            "dev": true
+        },
+        "domhandler": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+            "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1"
+            }
+        },
+        "domutils": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+            "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+            "dev": true,
+            "requires": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+            }
+        },
+        "entities": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+            "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+            "dev": true
+        },
+        "esprima": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+            "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+            "dev": true
+        },
+        "eventemitter2": {
+            "version": "0.4.14",
+            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+            "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+            "dev": true
+        },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
+        },
+        "extended": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/extended/-/extended-0.0.6.tgz",
+            "integrity": "sha1-f7i/e52uOXWG5IVwrP1kLHjlBmk=",
+            "requires": {
+                "extender": "~0.0.5"
+            }
+        },
+        "extender": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/extender/-/extender-0.0.10.tgz",
+            "integrity": "sha1-WJwHSCvmGhRgttgfnCSqZ+jzJM0=",
+            "requires": {
+                "declare.js": "~0.0.4"
+            }
+        },
+        "findup-sync": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+            "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+            "dev": true,
+            "requires": {
+                "glob": "~3.2.9",
+                "lodash": "~2.4.1"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "3.2.11",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                    "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2",
+                        "minimatch": "0.3"
+                    }
+                },
+                "lodash": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+                    "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                    "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
+                    }
+                }
+            }
+        },
+        "function-extended": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/function-extended/-/function-extended-0.0.9.tgz",
+            "integrity": "sha1-8os/B2I1R1PUrW7bgK6O2+4zQ2E=",
+            "dev": true,
+            "requires": {
+                "arguments-extended": "~0.0.3",
+                "extended": "~0.0.3",
+                "is-extended": "~0.0.3"
+            }
+        },
+        "getobject": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+            "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+            "dev": true
+        },
+        "glob": {
+            "version": "3.1.21",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+            "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "~1.2.0",
+                "inherits": "1",
+                "minimatch": "~0.2.11"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+                    "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+                    "dev": true
+                }
+            }
+        },
+        "graceful-fs": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+            "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+            "dev": true
+        },
+        "grunt": {
+            "version": "0.4.5",
+            "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+            "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+            "dev": true,
+            "requires": {
+                "async": "~0.1.22",
+                "coffee-script": "~1.3.3",
+                "colors": "~0.6.2",
+                "dateformat": "1.0.2-1.2.3",
+                "eventemitter2": "~0.4.13",
+                "exit": "~0.1.1",
+                "findup-sync": "~0.1.2",
+                "getobject": "~0.1.0",
+                "glob": "~3.1.21",
+                "grunt-legacy-log": "~0.1.0",
+                "grunt-legacy-util": "~0.2.0",
+                "hooker": "~0.2.3",
+                "iconv-lite": "~0.2.11",
+                "js-yaml": "~2.0.5",
+                "lodash": "~0.9.2",
+                "minimatch": "~0.2.12",
+                "nopt": "~1.0.10",
+                "rimraf": "~2.2.8",
+                "underscore.string": "~2.2.1",
+                "which": "~1.0.5"
+            }
+        },
+        "grunt-contrib-jshint": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
+            "integrity": "sha1-V+vMyofo8yevZkXYo8WG1IReTYE=",
+            "dev": true,
+            "requires": {
+                "hooker": "~0.2.3",
+                "jshint": "~2.5.0"
+            }
+        },
+        "grunt-exec": {
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/grunt-exec/-/grunt-exec-0.4.7.tgz",
+            "integrity": "sha1-QAUf+k6wyWV+BTuV6I1ENSocLCU=",
+            "dev": true
+        },
+        "grunt-it": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/grunt-it/-/grunt-it-1.0.2.tgz",
+            "integrity": "sha1-3R+6nOWINIdIqECghkBWuI6LDrs=",
+            "dev": true
+        },
+        "grunt-legacy-log": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+            "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+            "dev": true,
+            "requires": {
+                "colors": "~0.6.2",
+                "grunt-legacy-log-utils": "~0.1.1",
+                "hooker": "~0.2.3",
+                "lodash": "~2.4.1",
+                "underscore.string": "~2.3.3"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+                    "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+                    "dev": true
+                },
+                "underscore.string": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                    "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+                    "dev": true
+                }
+            }
+        },
+        "grunt-legacy-log-utils": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+            "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+            "dev": true,
+            "requires": {
+                "colors": "~0.6.2",
+                "lodash": "~2.4.1",
+                "underscore.string": "~2.3.3"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+                    "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+                    "dev": true
+                },
+                "underscore.string": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                    "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+                    "dev": true
+                }
+            }
+        },
+        "grunt-legacy-util": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+            "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+            "dev": true,
+            "requires": {
+                "async": "~0.1.22",
+                "exit": "~0.1.1",
+                "getobject": "~0.1.0",
+                "hooker": "~0.2.3",
+                "lodash": "~0.9.2",
+                "underscore.string": "~2.2.1",
+                "which": "~1.0.5"
+            }
+        },
+        "hooker": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+            "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+            "dev": true
+        },
+        "htmlparser2": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+            "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1",
+                "domhandler": "2.3",
+                "domutils": "1.5",
+                "entities": "1.0",
+                "readable-stream": "1.1"
+            }
+        },
+        "iconv-lite": {
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+            "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+            "dev": true
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "is-extended": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/is-extended/-/is-extended-0.0.10.tgz",
+            "integrity": "sha1-JE4UDfdbscmjEG9BL/GC+1NKbWI=",
+            "requires": {
+                "extended": "~0.0.3"
+            }
+        },
+        "isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "dev": true
+        },
+        "it": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/it/-/it-1.1.1.tgz",
+            "integrity": "sha1-1pOvzR9DMFFrUrVqTCf/jeuecNQ=",
+            "dev": true,
+            "requires": {
+                "array-extended": "~0.0.3",
+                "commander": "~1.1.1",
+                "date-extended": "~0.0.3",
+                "declare.js": "~0.0.3",
+                "extended": "~0.0.3",
+                "function-extended": "~0.0.3",
+                "glob": "~3.1.21",
+                "grunt": "~0.4.1",
+                "is-extended": "~0.0.3",
+                "object-extended": "~0.0.3",
+                "promise-extended": "~0.0.3",
+                "string-extended": "~0.0.3"
+            }
+        },
+        "js-yaml": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+            "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+            "dev": true,
+            "requires": {
+                "argparse": "~ 0.1.11",
+                "esprima": "~ 1.0.2"
+            }
+        },
+        "jshint": {
+            "version": "2.5.11",
+            "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
+            "integrity": "sha1-4tlYWLuxqngwAQii6BCZ+wlWIuA=",
+            "dev": true,
+            "requires": {
+                "cli": "0.6.x",
+                "console-browserify": "1.1.x",
+                "exit": "0.1.x",
+                "htmlparser2": "3.8.x",
+                "minimatch": "1.0.x",
+                "shelljs": "0.3.x",
+                "strip-json-comments": "1.0.x",
+                "underscore": "1.6.x"
+            },
+            "dependencies": {
+                "minimatch": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                    "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
+                    }
+                },
+                "underscore": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                    "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+                    "dev": true
+                }
+            }
+        },
+        "keypress": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+            "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo=",
+            "dev": true
+        },
+        "lodash": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+            "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+            "dev": true
+        },
+        "lru-cache": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "0.2.14",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+            "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+            "dev": true,
+            "requires": {
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
+            }
+        },
+        "nopt": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+            "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+            "dev": true,
+            "requires": {
+                "abbrev": "1"
+            }
+        },
+        "object-extended": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/object-extended/-/object-extended-0.0.7.tgz",
+            "integrity": "sha1-hP0j9WsVWCrrPoiwXLVdJDLWijM=",
+            "requires": {
+                "array-extended": "~0.0.4",
+                "extended": "~0.0.3",
+                "is-extended": "~0.0.3"
+            }
+        },
+        "promise-extended": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/promise-extended/-/promise-extended-0.0.9.tgz",
+            "integrity": "sha1-+xZPumbiO6hbxU80Ekp+m7j0Cd8=",
+            "dev": true,
+            "requires": {
+                "arguments-extended": "~0.0.3",
+                "array-extended": "~0.0.3",
+                "declare.js": "~0.0.3",
+                "extended": "~0.0.3",
+                "function-extended": "~0.0.3",
+                "is-extended": "~0.0.3"
+            }
+        },
+        "readable-stream": {
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+            "dev": true,
+            "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+            }
+        },
+        "rimraf": {
+            "version": "2.2.8",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+            "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+            "dev": true
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+        },
+        "shelljs": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+            "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+            "dev": true
+        },
+        "sigmund": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+            "dev": true
+        },
+        "string-extended": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/string-extended/-/string-extended-0.0.8.tgz",
+            "integrity": "sha1-dBlX3/SHsCcqee7FpE8jnubxfM0=",
+            "requires": {
+                "array-extended": "~0.0.5",
+                "date-extended": "~0.0.3",
+                "extended": "~0.0.3",
+                "is-extended": "~0.0.3"
+            }
+        },
+        "string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+            "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+            "dev": true
+        },
+        "underscore": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+            "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+            "dev": true
+        },
+        "underscore.string": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+            "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+            "dev": true
+        },
+        "which": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+            "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
         "node": ">=4.0.0"
     },
     "dependencies": {
+        "extended": "0.0.6",
         "is-extended": "0.0.10",
         "object-extended": "0.0.7",
-        "extended": "0.0.6",
+        "safer-buffer": "^2.1.2",
         "string-extended": "0.0.8"
     }
 }


### PR DESCRIPTION
Introduced in node 8, `new Buffer` is no longer recommended. From https://nodejs.org/de/docs/guides/buffer-constructor-deprecation/

> The Buffer() and new Buffer() constructors are not recommended for use due to security and usability concerns. Please use the new Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() construction methods instead.

This PR uses the recommended the polyfill approach for fixing this issue. It also adds more testing against other node versions to allow those using version 1 of this package to migrate to greater node versions.

I've created a `v1` branch so we can apply patches to it while maintaining semantic version compatibility.

 