### PR TITLE
Bump version to 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-csv",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "CSV parser and writer",
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",


### PR DESCRIPTION
* [FIXED] formatter.js: Disabling quote doesn't work #97
    * Changed to allow the `quote` option to be provided as a boolean so when set to false all quoting is ignored.
* [ADDED] `writeBOM` option when formatting a csv #180
* Added tests for #102