### PR TITLE
V3.6.0 rc

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-benchmark
-test
-node_modules
-.travis.yml
-History.md
-examples
-.nyc_output
-coverage

--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@
 * [ADDED] `skipRows` to allow skipping parsed rows see [parsing.md](./docs/parsing.md)
 * [ADDED] `skipLines` to allow skipping entire lines of a csv [parsing.md](./docs/parsing.md) [#267](https://github.com/C2FO/fast-csv/issues/267)
 * Exported formatting and parsing types.
+* Removed `.npmignore` in favor of `package.json` files
 
 # v3.5.0
 

--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+# v3.5.1
+
+* [ADDED] `maxRows` option to limit the number of rows parsed. [#275](https://github.com/C2FO/fast-csv/issues/275) [#277](https://github.com/C2FO/fast-csv/pull/277) - [@cbrittingham](https://github.com/cbrittingham)
+
 # v3.5.0
 
 * Upgraded dependencies

--- a/History.md
+++ b/History.md
@@ -1,8 +1,9 @@
-# v3.5.1
+# v3.6.0
 
 * [ADDED] `maxRows` option to limit the number of rows parsed. [#275](https://github.com/C2FO/fast-csv/issues/275) [#277](https://github.com/C2FO/fast-csv/pull/277) - [@cbrittingham](https://github.com/cbrittingham)
 * [ADDED] `skipRows` to allow skipping parsed rows see [parsing.md](./docs/parsing.md)
 * [ADDED] `skipLines` to allow skipping entire lines of a csv [parsing.md](./docs/parsing.md) [#267](https://github.com/C2FO/fast-csv/issues/267)
+* Exported formatting and parsing types.
 
 # v3.5.0
 

--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 # v3.5.1
 
 * [ADDED] `maxRows` option to limit the number of rows parsed. [#275](https://github.com/C2FO/fast-csv/issues/275) [#277](https://github.com/C2FO/fast-csv/pull/277) - [@cbrittingham](https://github.com/cbrittingham)
+* [ADDED] `skipRows` to allow skipping parsed rows see [parsing.md](./docs/parsing.md)
+* [ADDED] `skipLines` to allow skipping entire lines of a csv [parsing.md](./docs/parsing.md) [#267](https://github.com/C2FO/fast-csv/issues/267)
 
 # v3.5.0
 

--- a/benchmark/.eslintrc.js
+++ b/benchmark/.eslintrc.js
@@ -1,6 +1,8 @@
 module.exports = {
+    parserOptions: {
+        project: null,
+    },
     rules: {
         "no-console": 0,
-        "@typescript-eslint/no-var-requires": 0
     },
 };

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -2,7 +2,6 @@ const path = require('path');
 const fs = require('fs');
 const fastCsv = require('..');
 
-
 function camelize(str) {
     return str.replace(/_(.)/g, (a, b) => b.toUpperCase());
 }
@@ -11,7 +10,7 @@ const promisfyStream = (stream, expectedRows) => {
     let count = 0;
     return new Promise((res, rej) => {
         stream
-            .on('data', (row) => {
+            .on('data', row => {
                 count += 1;
             })
             .on('end', () => {
@@ -25,13 +24,14 @@ const promisfyStream = (stream, expectedRows) => {
     });
 };
 
-const benchmarkFastCsv = type => (num) => {
+const benchmarkFastCsv = type => num => {
     const file = path.resolve(__dirname, `./assets/${num}.${type}.csv`);
-    const stream = fs.createReadStream(file)
-        .pipe(fastCsv.parse({ headers: true }))
-        .transform((data) => {
+    const stream = fs
+        .createReadStream(file)
+        .pipe(fastCsv.parse({ headers: true, maxRows: 10 }))
+        .transform(data => {
             const ret = {};
-            [ 'first_name', 'last_name', 'email_address' ].forEach((prop) => {
+            ['first_name', 'last_name', 'email_address'].forEach(prop => {
                 ret[camelize(prop)] = data[prop];
             });
             ret.address = data.address;
@@ -47,7 +47,7 @@ async function benchmarkRun(title, num, m) {
     for (let i = 0; i < howMany; i += 1) {
         // eslint-disable-next-line no-await-in-loop
         await m(num);
-        console.log('%s: RUN(%d lines) 1 %dms', title, num, (new Date() - runStart));
+        console.log('%s: RUN(%d lines) 1 %dms', title, num, new Date() - runStart);
         runStart = new Date();
     }
     console.log('%s: 3xAVG for %d lines %dms', title, num, (new Date() - start) / howMany);
@@ -55,7 +55,7 @@ async function benchmarkRun(title, num, m) {
 
 function runBenchmarks(num, type) {
     console.log(`\nRUNNING ${num}.${type}.csv benchmarks`, num);
-    return benchmarkRun('fast-csv', num, benchmarkFastCsv(type))
+    return benchmarkRun('fast-csv', num, benchmarkFastCsv(type));
 }
 
 function benchmarks(type) {
@@ -67,7 +67,7 @@ function benchmarks(type) {
 benchmarks('nonquoted')
     .then(() => benchmarks('quoted'))
     .then(() => process.exit())
-    .catch((e) => {
+    .catch(e => {
         console.error(e.stack);
         return process.exit(1);
     });

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -17,6 +17,7 @@
     * [Ignoring Empty Rows](#csv-parse-ignoring-empty-rows)
     * [Transforming Rows](#csv-parse-transforming)
     * [Validating Rows](#csv-parse-validation)
+    * [Max Rows](#max-rows)
 
 <a name="parsing-options"></a>
 ## Options
@@ -45,6 +46,7 @@
 * `rtrim: {boolean} = false`: Set to `true` to right trim all fields.
 * `ltrim: {boolean} = false`: Set to `true` to left trim all fields.
 * `encoding: {string} = 'utf8'`: Passed to [StringDecoder](https://nodejs.org/api/string_decoder.html#string_decoder_new_stringdecoder_encoding) when decoding incoming buffers. Change if incoming content is not 'utf8' encoded.
+- `maxRows: {number}`: If number is `> 0` the specified number of rows will be parsed.(e.g. `100` would return the first 100 rows of data).
 
 <a name="parsing-events"></a>
 ## Events
@@ -583,5 +585,46 @@ Invalid [rowNumber=1] [row={"firstName":"bob","lastName":"yukon"}] [reason=Name 
 Valid [row={"firstName":"sally","lastName":"yukon"}]
 Valid [row={"firstName":"timmy","lastName":"yukon"}]
 Parsed 2 rows
+```
+
+<a name="max-rows"></a>
+[`examples/parsing/max_rows.example.example.js`](../examples/parsing/max_rows.example.js)
+
+In the following example there are 10 rows, but only 5 will be parsed because of the `maxRows` option.
+
+```javascript
+const rows = [
+    'header1,header2\n',
+    'col1,col1\n',
+    'col2,col2\n',
+    'col3,col3\n',
+    'col4,col4\n',
+    'col5,col5\n',
+    'col6,col6\n',
+    'col7,col7\n',
+    'col8,col8\n',
+    'col9,col9\n',
+    'col10,col10',
+];
+
+const stream = csv
+    .parse({ headers: true, maxRows: 5 })
+    .on('error', error => console.error(error))
+    .on('data', row => console.log(row))
+    .on('end', rowCount => console.log(`Parsed ${rowCount} rows`));
+
+rows.forEach(row => stream.write(row));
+stream.end();
+```
+
+Expected output
+
+```
+{ header1: 'col1', header2: 'col1' }
+{ header1: 'col2', header2: 'col2' }
+{ header1: 'col3', header2: 'col3' }
+{ header1: 'col4', header2: 'col4' }
+{ header1: 'col5', header2: 'col5' }
+Parsed 5 rows
 ```
 

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -18,6 +18,8 @@
     * [Transforming Rows](#csv-parse-transforming)
     * [Validating Rows](#csv-parse-validation)
     * [Max Rows](#max-rows)
+    * [Skip Rows](#skip-rows)
+    * [Skip Lines](#skip-lines)
 
 <a name="parsing-options"></a>
 ## Options
@@ -46,7 +48,9 @@
 * `rtrim: {boolean} = false`: Set to `true` to right trim all fields.
 * `ltrim: {boolean} = false`: Set to `true` to left trim all fields.
 * `encoding: {string} = 'utf8'`: Passed to [StringDecoder](https://nodejs.org/api/string_decoder.html#string_decoder_new_stringdecoder_encoding) when decoding incoming buffers. Change if incoming content is not 'utf8' encoded.
-- `maxRows: {number}`: If number is `> 0` the specified number of rows will be parsed.(e.g. `100` would return the first 100 rows of data).
+* `maxRows: {number} = 0`: If number is `> 0` the specified number of rows will be parsed.(e.g. `100` would return the first 100 rows of data).
+* `skipRows: {number} = 0`: If number is `> 0` the specified number of **parsed** rows will be skipped.
+* `skipLines: {number} = 0`: If number is `> 0` the specified number of lines will be skipped.
 
 <a name="parsing-events"></a>
 ## Events
@@ -627,4 +631,83 @@ Expected output
 { header1: 'col5', header2: 'col5' }
 Parsed 5 rows
 ```
+
+<a name="skip-rows"></a>
+[`examples/parsing/skip_rows.example.example.js`](../examples/parsing/skip_rows.example.js)
+
+In the following example the first 2 rows are skipped.
+
+**NOTE** Notice how the header row is not skipped, only the row.
+
+```javascript
+const rows = [
+    'header1,header2\n',
+    'col1,col1\n',
+    'col2,col2\n',
+    'col3,col3\n',
+    'col4,col4\n',
+    'col5,col5\n',
+    'col6,col6\n',
+];
+
+const stream = csv
+    .parse({ headers: true, skipRows: 2 })
+    .on('error', error => console.error(error))
+    .on('data', row => console.log(row))
+    .on('end', rowCount => console.log(`Parsed ${rowCount} rows`));
+
+rows.forEach(row => stream.write(row));
+stream.end();
+```
+
+Expected output
+
+```
+{ header1: 'col3', header2: 'col3' }
+{ header1: 'col4', header2: 'col4' }
+{ header1: 'col5', header2: 'col5' }
+{ header1: 'col6', header2: 'col6' }
+Parsed 4 rows
+```
+
+<a name="skip-lines"></a>
+[`examples/parsing/skip_lines.example.example.js`](../examples/parsing/skip_lines.example.js)
+
+In the following example the first 2 lines are skipped.
+
+**NOTE** Notice how the headers come from the third line because the first two are skipped.
+
+```javascript
+const csv = require('../../');
+
+const rows = [
+    'skip1_header1,skip1_header2\n',
+    'skip2_header1,skip2_header2\n',
+    'header1,header2\n',
+    'col1,col1\n',
+    'col2,col2\n',
+    'col3,col3\n',
+    'col4,col4\n',
+];
+
+const stream = csv
+    .parse({ headers: true, skipLines: 2 })
+    .on('error', error => console.error(error))
+    .on('data', row => console.log(row))
+    .on('end', rowCount => console.log(`Parsed ${rowCount} rows`));
+
+rows.forEach(row => stream.write(row));
+stream.end();
+```
+
+Expected output
+
+```
+{ header1: 'col1', header2: 'col1' }
+{ header1: 'col2', header2: 'col2' }
+{ header1: 'col3', header2: 'col3' }
+{ header1: 'col4', header2: 'col4' }
+Parsed 4 rows
+```
+
 

--- a/examples/parsing/max_rows.example.js
+++ b/examples/parsing/max_rows.example.js
@@ -1,0 +1,24 @@
+const csv = require('../../');
+
+const rows = [
+    'header1,header2\n',
+    'col1,col1\n',
+    'col2,col2\n',
+    'col3,col3\n',
+    'col4,col4\n',
+    'col5,col5\n',
+    'col6,col6\n',
+    'col7,col7\n',
+    'col8,col8\n',
+    'col9,col9\n',
+    'col10,col10',
+];
+
+const stream = csv
+    .parse({ headers: true, maxRows: 5 })
+    .on('error', error => console.error(error))
+    .on('data', row => console.log(row))
+    .on('end', rowCount => console.log(`Parsed ${rowCount} rows`));
+
+rows.forEach(row => stream.write(row));
+stream.end();

--- a/examples/parsing/skip_lines.example.js
+++ b/examples/parsing/skip_lines.example.js
@@ -1,0 +1,20 @@
+const csv = require('../../');
+
+const rows = [
+    'skip1_header1,skip1_header2\n',
+    'skip2_header1,skip2_header2\n',
+    'header1,header2\n',
+    'col1,col1\n',
+    'col2,col2\n',
+    'col3,col3\n',
+    'col4,col4\n',
+];
+
+const stream = csv
+    .parse({ headers: true, skipLines: 2 })
+    .on('error', error => console.error(error))
+    .on('data', row => console.log(row))
+    .on('end', rowCount => console.log(`Parsed ${rowCount} rows`));
+
+rows.forEach(row => stream.write(row));
+stream.end();

--- a/examples/parsing/skip_rows.example.js
+++ b/examples/parsing/skip_rows.example.js
@@ -1,0 +1,20 @@
+const csv = require('../../');
+
+const rows = [
+    'header1,header2\n',
+    'col1,col1\n',
+    'col2,col2\n',
+    'col3,col3\n',
+    'col4,col4\n',
+    'col5,col5\n',
+    'col6,col6\n',
+];
+
+const stream = csv
+    .parse({ headers: true, skipRows: 2 })
+    .on('error', error => console.error(error))
+    .on('data', row => console.log(row))
+    .on('end', rowCount => console.log(`Parsed ${rowCount} rows`));
+
+rows.forEach(row => stream.write(row));
+stream.end();

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "fast-csv",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "CSV parser and writer",
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",
   "scripts": {
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "build": "tsc",
     "mocha": "nyc mocha",
     "test": "npm run lint && npm run mocha",
@@ -14,6 +14,7 @@
     "benchmark": "node ./benchmark",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
+  "files": ["build/src/**"],
   "repository": {
     "type": "git",
     "url": "git@github.com:C2FO/fast-csv.git"

--- a/src/formatter/formatter/index.ts
+++ b/src/formatter/formatter/index.ts
@@ -1,5 +1,2 @@
-import RowFormatter from './RowFormatter';
-
-export default {
-    RowFormatter,
-};
+export { default as RowFormatter } from './RowFormatter';
+export { default as FieldFormatter } from './FieldFormatter';

--- a/src/formatter/index.ts
+++ b/src/formatter/index.ts
@@ -8,6 +8,7 @@ import CsvFormatterStream from './CsvFormatterStream';
 export { default as CsvFormatterStream } from './CsvFormatterStream';
 export * from './types';
 export * from './FormatterOptions';
+export * from './formatter';
 
 export const format = (options?: FormatterOptionsArgs): CsvFormatterStream =>
     new CsvFormatterStream(new FormatterOptions(options));

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,41 @@
  */
 
 import { deprecate } from 'util';
-import { parseStream, parseString, parseFile } from './parser';
+import { parseStream, parseString, parseFile, RowValidateCallback } from './parser';
 
-export { format, write, writeToStream, writeToBuffer, writeToString, writeToPath } from './formatter';
-export { parse, parseString, parseStream, parseFile } from './parser';
+export {
+    format,
+    write,
+    writeToStream,
+    writeToBuffer,
+    writeToString,
+    writeToPath,
+    FormatterOptionsArgs,
+    Row as FormatterRow,
+    RowMap as FormatterRowMap,
+    RowArray as FormatterRowArray,
+    RowHashArray as FormatterRowHashArray,
+    RowTransformCallback as FormatterRowTransformCallback,
+    RowTransformFunction as FormatterRowTransformFunction,
+} from './formatter';
+export {
+    parse,
+    parseString,
+    parseStream,
+    parseFile,
+    ParserOptionsArgs,
+    Row as ParserRow,
+    RowMap as ParserRowMap,
+    RowArray as ParserRowArray,
+    RowValidateCallback as ParserRowValidateCallback,
+    SyncRowValidate as ParserSyncRowValidate,
+    AsyncRowValidate as ParserAsyncRowValidate,
+    RowValidate as ParserRowValidate,
+    RowTransformCallback as ParserRowTransformCallback,
+    SyncRowTransform as ParserSyncRowTransform,
+    AsyncRowTransform as ParserAsyncRowTransform,
+    RowTransformFunction as ParserRowTransformFunction,
+} from './parser';
 
 export const fromString = deprecate(parseString, 'csv.fromString has been deprecated in favor of csv.parseString');
 export const fromStream = deprecate(parseStream, 'csv.fromStream has been deprecated in favor of csv.parseStream');

--- a/src/parser/ParserOptions.ts
+++ b/src/parser/ParserOptions.ts
@@ -16,6 +16,7 @@ export interface ParserOptionsArgs {
     ltrim?: boolean;
     rtrim?: boolean;
     encoding?: string;
+    maxRows?: number;
 }
 
 export class ParserOptions {
@@ -57,6 +58,10 @@ export class ParserOptions {
 
     public readonly encoding: string = 'utf8';
 
+    public readonly limitRows: boolean = false;
+
+    public readonly maxRows: number = 0;
+
     public constructor(opts?: ParserOptionsArgs) {
         Object.assign(this, opts || {});
         if (this.delimiter.length > 1) {
@@ -66,5 +71,9 @@ export class ParserOptions {
         this.escapeChar = this.escape ?? this.quote;
         this.supportsComments = !isNil(this.comment);
         this.NEXT_TOKEN_REGEXP = new RegExp(`([^\\s]|\\r\\n|\\n|\\r|${this.escapedDelimiter})`);
+
+        if (this.maxRows > 0) {
+            this.limitRows = true;
+        }
     }
 }

--- a/src/parser/ParserOptions.ts
+++ b/src/parser/ParserOptions.ts
@@ -17,6 +17,8 @@ export interface ParserOptionsArgs {
     rtrim?: boolean;
     encoding?: string;
     maxRows?: number;
+    skipLines?: number;
+    skipRows?: number;
 }
 
 export class ParserOptions {
@@ -61,6 +63,10 @@ export class ParserOptions {
     public readonly limitRows: boolean = false;
 
     public readonly maxRows: number = 0;
+
+    public readonly skipLines: number = 0;
+
+    public readonly skipRows: number = 0;
 
     public constructor(opts?: ParserOptionsArgs) {
         Object.assign(this, opts || {});

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -6,6 +6,8 @@ import CsvParserStream from './CsvParserStream';
 export { default as CsvParserStream } from './CsvParserStream';
 export * from './types';
 export * from './ParserOptions';
+export * from './parser';
+export * from './transforms';
 
 export const parse = (args?: ParserOptionsArgs): CsvParserStream => new CsvParserStream(new ParserOptions(args));
 

--- a/src/parser/parser/index.ts
+++ b/src/parser/parser/index.ts
@@ -1,2 +1,5 @@
 export { default as Parser } from './Parser';
 export { default as RowParser } from './RowParser';
+export { Scanner } from './Scanner';
+export { Token, MaybeToken } from './Token';
+export { ColumnParser, NonQuotedColumnParser, QuotedColumnParser } from './column';

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -2,7 +2,7 @@ export interface RowMap {
     [s: string]: string;
 }
 export type RowArray = string[];
-export type Row = string[] | object;
+export type Row = RowMap | RowArray;
 
 export interface RowValidationResult {
     row: Row | null;

--- a/test/formatter/FormatterOptions.test.ts
+++ b/test/formatter/FormatterOptions.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
-import { FormatterOptions, FormatterOptionsArgs } from '../../src/formatter';
+import { FormatterOptionsArgs } from '../../src';
+import { FormatterOptions } from '../../src/formatter';
 
 describe('FormatterOptions', () => {
     const createOptions = (opts: FormatterOptionsArgs = {}) => new FormatterOptions(opts);

--- a/test/formatter/formatter/FieldFormatter.test.ts
+++ b/test/formatter/formatter/FieldFormatter.test.ts
@@ -1,10 +1,10 @@
 import * as assert from 'assert';
-import FieldFormatter from '../../../src/formatter/formatter/FieldFormatter';
-import { FormatterOptions } from '../../../src/formatter/FormatterOptions';
+import { FormatterOptionsArgs } from '../../../src';
+import { FormatterOptions, FieldFormatter } from '../../../src/formatter';
 
 describe('FieldFormatter', () => {
     describe('#format', () => {
-        const createFormatter = (formatterOptions = {}, headers?: string[]) => {
+        const createFormatter = (formatterOptions: FormatterOptionsArgs = {}, headers?: string[]) => {
             const formatter = new FieldFormatter(new FormatterOptions(formatterOptions));
             if (headers) {
                 formatter.headers = headers;

--- a/test/formatter/formatter/RowFormatter.test.ts
+++ b/test/formatter/formatter/RowFormatter.test.ts
@@ -1,6 +1,12 @@
 import * as assert from 'assert';
-import { FormatterOptions, Row, RowArray, RowHashArray, RowMap, RowTransformCallback } from '../../../src/formatter';
-import RowFormatter from '../../../src/formatter/formatter/RowFormatter';
+import {
+    FormatterRow as Row,
+    FormatterRowArray as RowArray,
+    FormatterRowHashArray as RowHashArray,
+    FormatterRowMap as RowMap,
+    FormatterRowTransformCallback as RowTransformCallback,
+} from '../../../src';
+import { RowFormatter, FormatterOptions } from '../../../src/formatter';
 
 describe('RowFormatter', () => {
     const createFormatter = (formatterOptions = {}): RowFormatter =>

--- a/test/issues/issue111.test.ts
+++ b/test/issues/issue111.test.ts
@@ -1,6 +1,5 @@
 import * as assert from 'assert';
-import { Parser } from '../../src/parser/parser';
-import { ParserOptions } from '../../src/parser';
+import { ParserOptions, Parser } from '../../src/parser';
 
 describe('Issue #111 - https://github.com/C2FO/fast-csv/issues/111', () => {
     const createParser = (parserOptions = {}) => new Parser(new ParserOptions(parserOptions));

--- a/test/issues/issue131.test.ts
+++ b/test/issues/issue131.test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
 import { EOL } from 'os';
 import * as csv from '../../src';
-import { RowMap } from '../../src/parser';
 
 describe('Issue #131 - https://github.com/C2FO/fast-csv/issues/131', () => {
     const csvWithBom = [
@@ -10,7 +9,7 @@ describe('Issue #131 - https://github.com/C2FO/fast-csv/issues/131', () => {
     ].join(EOL);
 
     it('should parse a csv with a UTF-8 Byte Order Mark', next => {
-        const actual: RowMap[] = [];
+        const actual: csv.ParserRowMap[] = [];
         csv.parseString(csvWithBom, { headers: true })
             .on('data', data => actual.push(data))
             .on('end', (count: number) => {

--- a/test/issues/issue150.test.ts
+++ b/test/issues/issue150.test.ts
@@ -1,6 +1,5 @@
 import * as assert from 'assert';
-import { Parser } from '../../src/parser/parser';
-import { ParserOptions } from '../../src/parser';
+import { ParserOptions, Parser } from '../../src/parser';
 
 describe('Issue #150 - https://github.com/C2FO/fast-csv/issues/150', () => {
     const createParser = (parserOptions = {}) => new Parser(new ParserOptions(parserOptions));

--- a/test/issues/issue174.test.ts
+++ b/test/issues/issue174.test.ts
@@ -1,7 +1,7 @@
 import { EOL } from 'os';
 import * as assert from 'assert';
-import { Parser } from '../../src/parser/parser';
-import { ParserOptions, ParserOptionsArgs } from '../../src/parser';
+import { ParserOptionsArgs } from '../../src';
+import { Parser, ParserOptions } from '../../src/parser';
 
 describe('Issue #174 - https://github.com/C2FO/fast-csv/issues/174', () => {
     const createParser = (parserOptions: ParserOptionsArgs = {}) => new Parser(new ParserOptions(parserOptions));

--- a/test/issues/issue214.test.ts
+++ b/test/issues/issue214.test.ts
@@ -1,7 +1,6 @@
 import { EOL } from 'os';
 import * as assert from 'assert';
 import * as csv from '../../src';
-import { RowMap } from '../../src/parser';
 
 describe('Issue #214 - https://github.com/C2FO/fast-csv/issues/214', () => {
     const CSV_CONTENT = [
@@ -20,9 +19,9 @@ describe('Issue #214 - https://github.com/C2FO/fast-csv/issues/214', () => {
     ];
 
     it('should emit data when using the on method', next => {
-        const rows: RowMap[] = [];
+        const rows: csv.ParserRowMap[] = [];
         csv.parseString(CSV_CONTENT, { headers: true })
-            .on('data', (r: RowMap) => rows.push(r))
+            .on('data', (r: csv.ParserRowMap) => rows.push(r))
             .on('error', next)
             .on('end', (count: number) => {
                 assert.deepStrictEqual(rows, expectedRows);
@@ -32,9 +31,9 @@ describe('Issue #214 - https://github.com/C2FO/fast-csv/issues/214', () => {
     });
 
     it('should emit data when using the addListener method', next => {
-        const rows: RowMap[] = [];
+        const rows: csv.ParserRowMap[] = [];
         csv.parseString(CSV_CONTENT, { headers: true })
-            .addListener('data', (r: RowMap) => rows.push(r))
+            .addListener('data', (r: csv.ParserRowMap) => rows.push(r))
             .on('error', next)
             .on('end', (count: number) => {
                 assert.deepStrictEqual(rows, expectedRows);

--- a/test/issues/issue223.test.ts
+++ b/test/issues/issue223.test.ts
@@ -1,7 +1,6 @@
 import { EOL } from 'os';
 import * as assert from 'assert';
-import { Parser } from '../../src/parser/parser';
-import { ParserOptions } from '../../src/parser';
+import { Parser, ParserOptions } from '../../src/parser';
 
 describe('Issue #223 - https://github.com/C2FO/fast-csv/issues/223', () => {
     const createParser = (parserOptions = {}) => new Parser(new ParserOptions(parserOptions));

--- a/test/issues/issue87.test.ts
+++ b/test/issues/issue87.test.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Transform, TransformCallback } from 'stream';
 import * as csv from '../../src';
-import { Row } from '../../src/parser';
 
 describe('Issue #87 - https://github.com/C2FO/fast-csv/issues/87', () => {
     class MyStream extends Transform {
@@ -19,7 +18,7 @@ describe('Issue #87 - https://github.com/C2FO/fast-csv/issues/87', () => {
             this.rowCount = 0;
         }
 
-        private transform(data: Row, encoding: string, done: TransformCallback) {
+        private transform(data: csv.ParserRow, encoding: string, done: TransformCallback) {
             this.rowCount += 1;
             if (this.rowCount % 2 === 0) {
                 setTimeout(() => done(), 10);

--- a/test/parser/CsvParsingStream.test.ts
+++ b/test/parser/CsvParsingStream.test.ts
@@ -267,6 +267,24 @@ describe('CsvParserStream', () => {
         });
     });
 
+    describe('maxRows', () => {
+        it('should parse up to the specified number of maxRows', () => {
+            const maxRows = 3;
+            parseContentAndCollect(assets.withHeaders, { headers: true, maxRows }).then(({ count, rows }) => {
+                assert.deepStrictEqual(rows, assets.withHeaders.parsed.slice(0, maxRows));
+                assert.strictEqual(count, maxRows);
+            });
+        });
+
+        it('should parse all rows if maxRows === 0', () => {
+            const maxRows = 0;
+            parseContentAndCollect(assets.withHeaders, { headers: true, maxRows }).then(({ count, rows }) => {
+                assert.deepStrictEqual(rows, assets.withHeaders.parsed);
+                assert.strictEqual(count, rows.length);
+            });
+        });
+    });
+
     it('should emit an error for malformed rows', next => {
         assets.write(assets.malformed);
         const stream = csv.parseFile(assets.malformed.path, { headers: true });

--- a/test/parser/ParserOptions.test.ts
+++ b/test/parser/ParserOptions.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
-import { ParserOptions, ParserOptionsArgs } from '../../src/parser';
+import { ParserOptionsArgs } from '../../src';
+import { ParserOptions } from '../../src/parser';
 
 describe('ParserOptions', () => {
     const createOptions = (opts: ParserOptionsArgs = {}) => new ParserOptions(opts);

--- a/test/parser/ParserOptions.test.ts
+++ b/test/parser/ParserOptions.test.ts
@@ -183,4 +183,28 @@ describe('ParserOptions', () => {
             assert.strictEqual(opts.limitRows, false);
         });
     });
+
+    describe('#skipLines', () => {
+        it('should default skipLines to 0', () => {
+            const opts = createOptions();
+            assert.strictEqual(opts.skipLines, 0);
+        });
+
+        it('should set skipLines to the user provided option', () => {
+            const opts = createOptions({ skipLines: 10 });
+            assert.strictEqual(opts.skipLines, 10);
+        });
+    });
+
+    describe('#skipRows', () => {
+        it('should default skipLines to 0', () => {
+            const opts = createOptions();
+            assert.strictEqual(opts.skipRows, 0);
+        });
+
+        it('should set skipLines to the user provided option', () => {
+            const opts = createOptions({ skipRows: 10 });
+            assert.strictEqual(opts.skipRows, 10);
+        });
+    });
 });

--- a/test/parser/ParserOptions.test.ts
+++ b/test/parser/ParserOptions.test.ts
@@ -163,4 +163,24 @@ describe('ParserOptions', () => {
             assert.strictEqual(createOptions({ renameHeaders: false }).renameHeaders, false);
         });
     });
+
+    describe('#maxRows', () => {
+        it('should default maxRows 0 and limitRows to false', () => {
+            const opts = createOptions();
+            assert.strictEqual(opts.maxRows, 0);
+            assert.strictEqual(opts.limitRows, false);
+        });
+
+        it('should set maxRows to the provided option and limitRows to true if maxRows > 0', () => {
+            const opts = createOptions({ maxRows: 1 });
+            assert.strictEqual(opts.maxRows, 1);
+            assert.strictEqual(opts.limitRows, true);
+        });
+
+        it('should set maxRows to the provided option and limitRows to true if maxRows === 0', () => {
+            const opts = createOptions({ maxRows: 0 });
+            assert.strictEqual(opts.maxRows, 0);
+            assert.strictEqual(opts.limitRows, false);
+        });
+    });
 });

--- a/test/parser/assets/index.ts
+++ b/test/parser/assets/index.ts
@@ -2,11 +2,13 @@ import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import * as path from 'path';
 import alternateEncoding from './alternateEncoding';
 import noHeadersAndQuotes from './noHeadersAndQuotes';
+import skipLines from './skipLines';
 import withHeaders from './withHeaders';
 import withHeadersAndQuotes from './withHeadersAndQuotes';
 import withHeadersAndAlternateQuote from './withHeadersAndAlternateQuote';
 import withHeadersAndMissingColumns from './withHeadersAndMissingColumns';
 import withHeadersAlternateDelimiter from './withHeadersAlternateDelimiter';
+import withHeadersSkippedLines from './withHeadersSkippedLines';
 import headerColumnMismatch from './headerColumnMismatch';
 import malformed from './malformed';
 import trailingComma from './trailingComma';
@@ -32,11 +34,13 @@ const write = (opts: PathAndContent): void => {
 export default {
     write,
     alternateEncoding,
+    skipLines,
     withHeaders,
     withHeadersAndQuotes,
     withHeadersAndAlternateQuote,
     withHeadersAndMissingColumns,
     withHeadersAlternateDelimiter,
+    withHeadersSkippedLines,
     noHeadersAndQuotes,
     headerColumnMismatch,
     malformed,

--- a/test/parser/assets/skipLines.ts
+++ b/test/parser/assets/skipLines.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { resolve } from 'path';
+import { EOL } from 'os';
+
+export default {
+    path: resolve(__dirname, 'tmp', 'skip_lines.csv'),
+
+    content: [
+        'Skip First1,Last1,skip.email2@email.com',
+        'Skip First2,Skip Last2,skip.email2@email.com',
+        'First1,Last1,email1@email.com',
+        'First2,Last2,email2@email.com',
+        'First3,Last3,email3@email.com',
+        'First4,Last4,email4@email.com',
+        'First5,Last5,email5@email.com',
+        'First6,Last6,email6@email.com',
+        'First7,Last7,email7@email.com',
+        'First8,Last8,email8@email.com',
+        'First9,Last9,email9@email.com',
+    ].join(EOL),
+
+    parsed: [
+        ['First1', 'Last1', 'email1@email.com'],
+        ['First2', 'Last2', 'email2@email.com'],
+        ['First3', 'Last3', 'email3@email.com'],
+        ['First4', 'Last4', 'email4@email.com'],
+        ['First5', 'Last5', 'email5@email.com'],
+        ['First6', 'Last6', 'email6@email.com'],
+        ['First7', 'Last7', 'email7@email.com'],
+        ['First8', 'Last8', 'email8@email.com'],
+        ['First9', 'Last9', 'email9@email.com'],
+    ],
+};

--- a/test/parser/assets/withHeadersSkippedLines.ts
+++ b/test/parser/assets/withHeadersSkippedLines.ts
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { resolve } from 'path';
+import { EOL } from 'os';
+
+export default {
+    path: resolve(__dirname, 'tmp', 'with_headers_skip_lines.csv'),
+
+    content: [
+        'skip_one_first_name,skip_one_last_name,skip_one_email_address',
+        'skip_two_first_name,skip_two_last_name,skip_two_email_address',
+        'first_name,last_name,email_address',
+        'First1,Last1,email1@email.com',
+        'First2,Last2,email2@email.com',
+        'First3,Last3,email3@email.com',
+        'First4,Last4,email4@email.com',
+        'First5,Last5,email5@email.com',
+        'First6,Last6,email6@email.com',
+        'First7,Last7,email7@email.com',
+        'First8,Last8,email8@email.com',
+        'First9,Last9,email9@email.com',
+    ].join(EOL),
+
+    parsed: [
+        {
+            first_name: 'First1',
+            last_name: 'Last1',
+            email_address: 'email1@email.com',
+        },
+        {
+            first_name: 'First2',
+            last_name: 'Last2',
+            email_address: 'email2@email.com',
+        },
+        {
+            first_name: 'First3',
+            last_name: 'Last3',
+            email_address: 'email3@email.com',
+        },
+        {
+            first_name: 'First4',
+            last_name: 'Last4',
+            email_address: 'email4@email.com',
+        },
+        {
+            first_name: 'First5',
+            last_name: 'Last5',
+            email_address: 'email5@email.com',
+        },
+        {
+            first_name: 'First6',
+            last_name: 'Last6',
+            email_address: 'email6@email.com',
+        },
+        {
+            first_name: 'First7',
+            last_name: 'Last7',
+            email_address: 'email7@email.com',
+        },
+        {
+            first_name: 'First8',
+            last_name: 'Last8',
+            email_address: 'email8@email.com',
+        },
+        {
+            first_name: 'First9',
+            last_name: 'Last9',
+            email_address: 'email9@email.com',
+        },
+    ],
+};

--- a/test/parser/parser/Parser.test.ts
+++ b/test/parser/parser/Parser.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
-import { ParserOptions, ParserOptionsArgs } from '../../../src/parser';
-import { Parser } from '../../../src/parser/parser';
+import { ParserOptionsArgs } from '../../../src';
+import { ParserOptions, Parser } from '../../../src/parser';
 
 describe('Parser', () => {
     const createParser = (parserOptions: ParserOptionsArgs = {}) => new Parser(new ParserOptions(parserOptions));

--- a/test/parser/parser/RowParser.test.ts
+++ b/test/parser/parser/RowParser.test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
-import { ParserOptions, ParserOptionsArgs } from '../../../src/parser';
-import RowParser from '../../../src/parser/parser/RowParser';
-import { Scanner } from '../../../src/parser/parser/Scanner';
+import { ParserOptionsArgs } from '../../../src';
+import { ParserOptions, Scanner, RowParser } from '../../../src/parser';
 
 describe('RowParser', () => {
     const parse = (line: string, hasMoreData = false, parserOpts: ParserOptionsArgs = {}) => {

--- a/test/parser/parser/Scanner.test.ts
+++ b/test/parser/parser/Scanner.test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
-import { ParserOptions, ParserOptionsArgs } from '../../../src/parser';
-import { Scanner } from '../../../src/parser/parser/Scanner';
-import { MaybeToken, Token } from '../../../src/parser/parser/Token';
+import { ParserOptionsArgs } from '../../../src';
+import { ParserOptions, Scanner, Token, MaybeToken } from '../../../src/parser';
 
 const createOptions = (opts: ParserOptionsArgs = {}) => new ParserOptions(opts);
 describe('Scanner', () => {

--- a/test/parser/parser/column/ColumnParser.test.ts
+++ b/test/parser/parser/column/ColumnParser.test.ts
@@ -1,8 +1,6 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { ParserOptions } from '../../../../src/parser';
-import { ColumnParser } from '../../../../src/parser/parser/column';
-import { Scanner } from '../../../../src/parser/parser/Scanner';
+import { ParserOptions, Scanner, ColumnParser } from '../../../../src/parser';
 
 describe('ColumnParser', () => {
     describe('#parse', () => {

--- a/test/parser/parser/column/NonQuotedColumnParser.test.ts
+++ b/test/parser/parser/column/NonQuotedColumnParser.test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
-import { ParserOptions, ParserOptionsArgs } from '../../../../src/parser';
-import { NonQuotedColumnParser } from '../../../../src/parser/parser/column';
-import { Scanner } from '../../../../src/parser/parser/Scanner';
+import { ParserOptionsArgs } from '../../../../src';
+import { ParserOptions, Scanner, NonQuotedColumnParser } from '../../../../src/parser';
 
 describe('NonQuotedColumnParser', () => {
     const parse = (line: string, hasMoreData = false, parserOpts: ParserOptionsArgs = {}) => {

--- a/test/parser/parser/column/QuotedColumnParser.test.ts
+++ b/test/parser/parser/column/QuotedColumnParser.test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
-import { ParserOptions, ParserOptionsArgs } from '../../../../src/parser';
-import { QuotedColumnParser } from '../../../../src/parser/parser/column';
-import { Scanner } from '../../../../src/parser/parser/Scanner';
+import { ParserOptionsArgs } from '../../../../src';
+import { ParserOptions, QuotedColumnParser, Scanner } from '../../../../src/parser';
 
 describe('QuotedColumnParser', () => {
     const parse = (line: string, hasMoreData = false, parserOpts: ParserOptionsArgs = {}) => {

--- a/test/parser/transforms/HeaderTransformer.test.ts
+++ b/test/parser/transforms/HeaderTransformer.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
-import { HeaderTransformer } from '../../../src/parser/transforms';
-import { ParserOptions, ParserOptionsArgs, RowArray, RowValidationResult } from '../../../src/parser';
+import { ParserOptionsArgs, ParserRowArray as RowArray } from '../../../src';
+import { ParserOptions, RowValidationResult, HeaderTransformer } from '../../../src/parser';
 
 describe('HeaderTransformer', () => {
     const createHeaderTransformer = (opts?: ParserOptionsArgs) => new HeaderTransformer(new ParserOptions(opts));

--- a/test/parser/transforms/RowTransformerValidator.test.ts
+++ b/test/parser/transforms/RowTransformerValidator.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
-import { Row, RowArray, RowValidationResult } from '../../../src/parser';
-import { RowTransformerValidator } from '../../../src/parser/transforms';
+import { ParserRow as Row, ParserRowArray as RowArray } from '../../../src';
+import { RowValidationResult, RowTransformerValidator } from '../../../src/parser';
 
 describe('RowTransformerValidator', () => {
     const createRowTransformerValidator = () => new RowTransformerValidator();


### PR DESCRIPTION
* [ADDED] `maxRows` option to limit the number of rows parsed. #275 #277 - @cbrittingham
* [ADDED] `skipRows` to allow skipping parsed rows see parsing.md
* [ADDED] `skipLines` to allow skipping entire lines of a csv parsing.md #267
* Exported formatting and parsing types.