### PR TITLE
Emit error when duplicate header is encountered $276

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,8 @@
 * [ADDED] Ability to Transform Header [#287](https://github.com/C2FO/fast-csv/issues/287)
 * [ADDED] Example require and import to README [#301](https://github.com/C2FO/fast-csv/issues/301)
 * [ADDED] Added new formatting option `alwaysWriteHeaders` to always write headers even if no rows are provided [#300](https://github.com/C2FO/fast-csv/issues/300)
+* [FIXED] Issue with duplicate headers causing dataloss, duplicate headers will can an error to be emitted. [#276](https://github.com/C2FO/fast-csv/issues/276)
+* [FIXED] Issue where an error thrown while processing rows causes stream continue to parse, causing duplicate writes or swallowed exceptions.
 
 # v3.6.0
 

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -28,7 +28,7 @@ const benchmarkFastCsv = type => num => {
     const file = path.resolve(__dirname, `./assets/${num}.${type}.csv`);
     const stream = fs
         .createReadStream(file)
-        .pipe(fastCsv.parse({ headers: true, maxRows: 10 }))
+        .pipe(fastCsv.parse({ headers: true }))
         .transform(data => {
             const ret = {};
             ['first_name', 'last_name', 'email_address'].forEach(prop => {

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -38,6 +38,7 @@
   *  If you wish to discard the first row and use your own headers set to a `string[]` and set the `renameHeaders` option to `true`
   *  If you wish to transform the headers you can provide a transform function. 
       *  **NOTE** This will always rename the headers
+  * **NOTE** If headers either parsed, provided or transformed are NOT unique, then an error will be emitted and the stream will stop parsing.
 * `renameHeaders: {boolean} = false`: If you want the first line of the file to be removed and replaced by the one provided in the `headers` option. 
   * **NOTE** This option should only be used if the `headers` option is a `string[]`
   * **NOTE** If the `headers` option is a function then this option is always set to true.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-csv",
-  "version": "3.4.0",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -207,6 +207,15 @@
         "@types/lodash": "*"
       }
     },
+    "@types/lodash.groupby": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.groupby/-/lodash.groupby-4.6.6.tgz",
+      "integrity": "sha512-kwg3T7Ia63KtDNoQQR8hKrLHCAgrH4I44l5uEMuA6JCbj7DiSccaV4tNV1vbjtAOpX990SolVthJCmBVtRVRgw==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/lodash.isboolean": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.isboolean/-/lodash.isboolean-3.0.6.tgz",
@@ -265,6 +274,15 @@
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.partition/-/lodash.partition-4.6.6.tgz",
       "integrity": "sha512-s8ZNNFWhBgTKI4uNxVrTs3Aa7UQoi7Fesw55bfpBBMCLda+uSuwDyuax8ka9aBy8Ccsjp2SiS034DkSZa+CzVA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.uniq": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.uniq/-/lodash.uniq-4.5.6.tgz",
+      "integrity": "sha512-XHNMXBtiwsWZstZMyxOYjr0e8YYWv0RgPlzIHblTuwBBiWo2MzWVaTBihtBpslb5BglgAWIeBv69qt1+RTRW1A==",
       "dev": true,
       "requires": {
         "@types/lodash": "*"
@@ -2263,6 +2281,11 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
+    },
     "lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
@@ -2304,6 +2327,11 @@
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "log-driver": {
       "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "benchmark": "node ./benchmark",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
-  "files": ["build/src/**"],
+  "files": [
+    "build/src/**"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:C2FO/fast-csv.git"
@@ -40,6 +42,8 @@
     "@types/lodash.isstring": "^4.0.6",
     "@types/lodash.isundefined": "^3.0.6",
     "@types/lodash.partition": "^4.6.6",
+    "@types/lodash.uniq": "^4.5.6",
+    "@types/lodash.groupby": "^4.6.6",
     "@types/mocha": "^5.2.7",
     "@types/sinon": "^7.5.1",
     "@typescript-eslint/eslint-plugin": "^2.11.0",
@@ -66,11 +70,13 @@
   "dependencies": {
     "@types/node": "^12.12.17",
     "lodash.escaperegexp": "^4.1.2",
+    "lodash.groupby": "^4.6.0",
     "lodash.isboolean": "^3.0.3",
     "lodash.isequal": "^4.5.0",
     "lodash.isfunction": "^3.0.9",
     "lodash.isnil": "^4.0.0",
     "lodash.isstring": "^4.0.1",
-    "lodash.isundefined": "^3.0.1"
+    "lodash.isundefined": "^3.0.1",
+    "lodash.uniq": "^4.5.0"
   }
 }

--- a/test/issues/issue68.test.ts
+++ b/test/issues/issue68.test.ts
@@ -18,11 +18,7 @@ describe('Issue #68 - https://github.com/C2FO/fast-csv/issues/68', () => {
         d.run(() =>
             csv
                 .parseFile(path.resolve(__dirname, './assets/issue68-invalid.tsv'), { headers: true, delimiter: '\t' })
-                .on('data', () => null)
-                .on('end', (count: number) => {
-                    assert.strictEqual(count, 20000);
-                    throw new Error('End error');
-                }),
+                .on('data', () => null),
         );
     });
 

--- a/test/parser/CsvParsingStream.test.ts
+++ b/test/parser/CsvParsingStream.test.ts
@@ -233,6 +233,13 @@ describe('CsvParserStream', () => {
             stream.end();
         });
 
+        it('should propagate an error if headers are not unique', next => {
+            const stream = csv.parse({ headers: true });
+            listenForError(stream, 'Duplicate headers found ["first_name"]', next);
+            stream.write(assets.duplicateHeaders.content);
+            stream.end();
+        });
+
         it('should discard extra columns that do not map to a header when discardUnmappedColumns is true', () =>
             parseContentAndCollect(assets.headerColumnMismatch, { headers: true, discardUnmappedColumns: true }).then(
                 ({ count, rows }) => {

--- a/test/parser/assets/duplicateHeaders.ts
+++ b/test/parser/assets/duplicateHeaders.ts
@@ -1,0 +1,13 @@
+import { resolve } from 'path';
+import { EOL } from 'os';
+
+export default {
+    path: resolve(__dirname, 'tmp', 'duplicate_header.csv'),
+
+    content: [
+        'first_name,first_name,email_address,address',
+        'First1,First1,email1@email.com,"1 Street St, State ST, 88888"',
+    ].join(EOL),
+
+    parsed: [],
+};

--- a/test/parser/assets/index.ts
+++ b/test/parser/assets/index.ts
@@ -13,6 +13,7 @@ import headerColumnMismatch from './headerColumnMismatch';
 import malformed from './malformed';
 import trailingComma from './trailingComma';
 import emptyRows from './emptyRows';
+import duplicateHeaders from './duplicateHeaders';
 
 export interface PathAndContent {
     path: string;
@@ -34,6 +35,7 @@ const write = (opts: PathAndContent): void => {
 export default {
     write,
     alternateEncoding,
+    duplicateHeaders,
     skipLines,
     withHeaders,
     withHeadersAndQuotes,

--- a/test/parser/transforms/HeaderTransformer.test.ts
+++ b/test/parser/transforms/HeaderTransformer.test.ts
@@ -81,6 +81,28 @@ describe('HeaderTransformer', () => {
                 });
         });
 
+        it('should throw an error if headers is true and the first row is not unique', () => {
+            const row1 = ['origHeader1', 'origHeader1', 'origHeader2'];
+            const transformer = createHeaderTransformer({ headers: true });
+            return transform(row1, transformer).then(
+                () => assert.fail('should have failed'),
+                err => assert.strictEqual(err.message, 'Duplicate headers found ["origHeader1"]'),
+            );
+        });
+
+        it('should throw an error if headers is an array and is not unique', () => {
+            const headers = ['origHeader1', 'origHeader1', 'origHeader2'];
+            assert.throws(() => createHeaderTransformer({ headers }), /Duplicate headers found \["origHeader1"]/);
+        });
+
+        it('should throw an error if headers is a transform and returns non-unique values', () => {
+            const row = ['h1', 'h2', 'h3'];
+            const transformer = createHeaderTransformer({ headers: () => ['h1', 'h1', 'h3'] });
+            return transform(row, transformer).catch(err =>
+                assert.strictEqual(err.message, 'Duplicate headers found ["h1"]'),
+            );
+        });
+
         it('should throw an error if headers is not defined and renameHeaders is true', () => {
             const row1 = ['origHeader1', 'origHeader2'];
             const transformer = createHeaderTransformer({ renameHeaders: true });


### PR DESCRIPTION
* [FIXED] Issue with duplicate headers causing dataloss, duplicate headers will can an error to be emitted. #276
* [FIXED] Issue where an error thrown while processing rows causes stream continue to parse, causing duplicate writes or swallowed exceptions.
