### PR TITLE
v3.7.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,7 +48,8 @@ module.exports = {
         "prettier/prettier": "error",
         "indent": [
             "error",
-            4
+            4,
+            { "SwitchCase": 1 }
         ],
         "no-restricted-syntax": ["error", "ForInStatement", "LabeledStatement", "WithStatement"],
         "object-curly-spacing": ["error", "always"],

--- a/History.md
+++ b/History.md
@@ -3,6 +3,8 @@
 * [ADDED] Ability to Transform Header [#287](https://github.com/C2FO/fast-csv/issues/287)
 * [ADDED] Example require and import to README [#301](https://github.com/C2FO/fast-csv/issues/301)
 * [ADDED] Added new formatting option `alwaysWriteHeaders` to always write headers even if no rows are provided [#300](https://github.com/C2FO/fast-csv/issues/300)
+* [FIXED] Issue with duplicate headers causing dataloss, duplicate headers will can an error to be emitted. [#276](https://github.com/C2FO/fast-csv/issues/276)
+* [FIXED] Issue where an error thrown while processing rows causes stream continue to parse, causing duplicate writes or swallowed exceptions.
 
 # v3.6.0
 

--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+# v3.7.0
+
+* [ADDED] Ability to Transform Header [#287](https://github.com/C2FO/fast-csv/issues/287)
+
 # v3.6.0
 
 * [ADDED] `maxRows` option to limit the number of rows parsed. [#275](https://github.com/C2FO/fast-csv/issues/275) [#277](https://github.com/C2FO/fast-csv/pull/277) - [@cbrittingham](https://github.com/cbrittingham)

--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 # v3.7.0
 
 * [ADDED] Ability to Transform Header [#287](https://github.com/C2FO/fast-csv/issues/287)
+* [ADDED] Example require and import to README [#301](https://github.com/C2FO/fast-csv/issues/301)
 
 # v3.6.0
 

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 * [ADDED] Ability to Transform Header [#287](https://github.com/C2FO/fast-csv/issues/287)
 * [ADDED] Example require and import to README [#301](https://github.com/C2FO/fast-csv/issues/301)
+* [ADDED] Added new formatting option `alwaysWriteHeaders` to always write headers even if no rows are provided [#300](https://github.com/C2FO/fast-csv/issues/300)
 
 # v3.6.0
 

--- a/History.md
+++ b/History.md
@@ -3,8 +3,10 @@
 * [ADDED] Ability to Transform Header [#287](https://github.com/C2FO/fast-csv/issues/287)
 * [ADDED] Example require and import to README [#301](https://github.com/C2FO/fast-csv/issues/301)
 * [ADDED] Added new formatting option `alwaysWriteHeaders` to always write headers even if no rows are provided [#300](https://github.com/C2FO/fast-csv/issues/300)
-* [FIXED] Issue with duplicate headers causing dataloss, duplicate headers will can an error to be emitted. [#276](https://github.com/C2FO/fast-csv/issues/276)
+* [ADDED] Appending to csv example and docs [#272](https://github.com/C2FO/fast-csv/issues/300)
+* [FIXED] Issue with duplicate headers causing dataloss, duplicate headers will can an error to be emitted. [#276](https://github.com/C2FO/fast-csv/issues/272)
 * [FIXED] Issue where an error thrown while processing rows causes stream continue to parse, causing duplicate writes or swallowed exceptions.
+
 
 # v3.6.0
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@ Fast-csv is library for parsing and formatting csvs or any other delimited value
 
 `npm install -S fast-csv`
 
+## Usage
+
+To use `fast-csv` in `javascript` you can require the module/
+
+```js
+const csv = require('fast-csv');
+```
+
+To import with typescript 
+
+```typescript
+import * as csv from 'fast-csv';
+```
+
 ## Documentation
 
 * [Parsing Docs](./docs/parsing.md)
@@ -54,4 +68,5 @@ MIT <https://github.com/C2FO/fast-csv/raw/master/LICENSE>
 * Code: `git clone git://github.com/C2FO/fast-csv.git`
 * Website: <http://c2fo.com>
 * Twitter: [http://twitter.com/c2fo](http://twitter.com/c2fo) - 877.465.4045
+
 

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -28,7 +28,7 @@ const benchmarkFastCsv = type => num => {
     const file = path.resolve(__dirname, `./assets/${num}.${type}.csv`);
     const stream = fs
         .createReadStream(file)
-        .pipe(fastCsv.parse({ headers: true, maxRows: 10 }))
+        .pipe(fastCsv.parse({ headers: true }))
         .transform(data => {
             const ret = {};
             ['first_name', 'last_name', 'email_address'].forEach(prop => {

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -26,6 +26,7 @@
     * [`quoteColumns`](#examples-quote-columns)
     * [`quoteHeaders`](#examples-quote-headers)
     * [Transforming Rows](#examples-transforming)
+    * [Appending To A CSV](#examples-appending)
 
 <a name="options"></a>
 ## Options
@@ -838,4 +839,88 @@ VALUE1A,VALUE2A
 VALUE1A,VALUE2A
 VALUE1A,VALUE2A
 VALUE1A,VALUE2A
+```
+
+<a name="examples-appending"></a>
+### Appending To A CSV
+
+[`examples/formatting/append.example.js`](../examples/formatting/append.example.js)
+
+In this example a new csv is created then appended to.
+
+```javascript
+const path = require('path');
+const fs = require('fs');
+
+const write = (filestream, rows, options) => {
+    return new Promise((res, rej) => {
+        csv.writeToStream(filestream, rows, options)
+            .on('error', err => rej(err))
+            .on('finish', () => res());
+    });
+};
+
+// create a new csv
+const createCsv = (filePath, rows) => {
+    const csvFile = fs.createWriteStream(filePath);
+    return write(csvFile, rows, { headers: true, includeEndRowDelimiter: true });
+};
+
+// append the rows to the csv
+const appendToCsv = (filePath, rows = []) => {
+    const csvFile = fs.createWriteStream(filePath, { flags: 'a' });
+    // notice how headers are set to false
+    return write(csvFile, rows, { headers: false });
+};
+
+// read the file
+const readFile = filePath => {
+    return new Promise((res, rej) => {
+        fs.readFile(filePath, (err, contents) => {
+            if (err) {
+                return rej(err);
+            }
+            return res(contents);
+        });
+    });
+};
+
+const csvFilePath = path.resolve(__dirname, 'tmp', 'append.csv');
+
+// 1. create the csv
+createCsv(csvFilePath, [
+    { a: 'a1', b: 'b1', c: 'c1' },
+    { a: 'a2', b: 'b2', c: 'c2' },
+    { a: 'a3', b: 'b3', c: 'c3' },
+])
+    .then(() => {
+        // 2. append to the csv
+        return appendToCsv(csvFilePath, [
+            { a: 'a4', b: 'b4', c: 'c4' },
+            { a: 'a5', b: 'b5', c: 'c5' },
+            { a: 'a6', b: 'b6', c: 'c6' },
+        ]);
+    })
+    .then(() => readFile(csvFilePath))
+    .then(contents => {
+        console.log(`${contents}`);
+    })
+    .catch(err => {
+        console.error(err.stack);
+        process.exit(1);
+    });
+
+
+```
+
+Expected output
+
+```
+a,b,c
+a1,b1,c1
+a2,b2,c2
+a3,b3,c3
+a4,b4,c4
+a5,b5,c5
+a6,b6,c6
 ```

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -52,6 +52,8 @@
   *  If there is not a headers row and you want to provide one then set to a `string[]`
       * **NOTE** If the row is an object the headers must match fields in the object, otherwise you will end up with empty fields
       * **NOTE** If there are more headers than columns then additional empty columns will be added
+* `alwaysWriteHeaders: {boolean} = false`: Set to true if you always want headers written, even if no rows are written.
+  * **NOTE** This will throw an error if headers are not specified as an array.
 * `quoteColumns: {boolean|boolean[]|{[string]: boolean} = false`
    * If `true` then columns and headers will be quoted (unless `quoteHeaders` is specified).
    * If it is an object then each key that has a true value will be quoted ((unless `quoteHeaders` is specified)

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -13,6 +13,7 @@
     * [First Row As Headers](#csv-parse-first-row-as-headers)
     * [Custom Headers](#csv-parse-custom-headers)
     * [Renaming Headers](#csv-parse-renaming-headers)
+    * [Transforming Headers](#csv-parse-transforming-headers)
     * [Skipping Columns](#csv-parse-skipping-columns)
     * [Ignoring Empty Rows](#csv-parse-ignoring-empty-rows)
     * [Transforming Rows](#csv-parse-transforming)
@@ -31,12 +32,15 @@
   * `"first,name",last name`
 * `escape: {string} = '"'`: The character to used tp escape quotes inside of a quoted field.
     * `i.e`: `First,"Name"' => '"First,""Name"""`
-* `headers: {boolean|string[]} = false`:
+* `headers: {boolean|string[]|(string[]) => string[])} = false`:
   *  If you want the first row to be treated as headers then set to `true`
   *  If there is not a headers row and you want to provide one then set to a `string[]`
   *  If you wish to discard the first row and use your own headers set to a `string[]` and set the `renameHeaders` option to `true`
-* `renameHeaders: {boolean} = false`: If you want the first line of the file to be removed and replaced by the one provided in the `headers` option.
+  *  If you wish to transform the headers you can provide a transform function. 
+      *  **NOTE** This will always rename the headers
+* `renameHeaders: {boolean} = false`: If you want the first line of the file to be removed and replaced by the one provided in the `headers` option. 
   * **NOTE** This option should only be used if the `headers` option is a `string[]`
+  * **NOTE** If the `headers` option is a function then this option is always set to true.
 * `ignoreEmpty: {boolean} = false`: If you wish to ignore empty rows.
   * **NOTE** this will discard columns that are all white space or delimiters.
 * `comment: {string} = null`: If your CSV contains comments you can use this option to ignore lines that begin with the specified character (e.g. `#`).
@@ -334,6 +338,39 @@ Expected output
 ```
 { a: 'a1', b: 'b1' }
 { a: 'a2', b: 'b2' }
+Parsed 2 rows
+```
+
+<a name="csv-parse-transforming-headers"></a>
+### Transforming Headers
+
+If the CSV contains a header row but you want transform the headers you can provide a function to the `headers` option.
+
+[`examples/parsing/rename_headers.example.js`](../examples/parsing/rename_headers.example.js)
+
+```javascript
+const { EOL } = require('os');
+
+const CSV_STRING = ['header1,header2', 'a1,b1', 'a2,b2'].join(EOL);
+
+const stream = csv
+    .parse({
+        headers: headers => headers.map(h => h.toUpperCase()),
+    })
+    .on('error', error => console.error(error))
+    .on('data', row => console.log(row))
+    .on('end', rowCount => console.log(`Parsed ${rowCount} rows`));
+
+stream.write(CSV_STRING);
+stream.end();
+
+```
+
+Expected output
+
+```
+{ HEADER1: 'a1', HEADER2: 'b1' }
+{ HEADER1: 'a2', HEADER2: 'b2' }
 Parsed 2 rows
 ```
 
@@ -709,5 +746,6 @@ Expected output
 { header1: 'col4', header2: 'col4' }
 Parsed 4 rows
 ```
+
 
 

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -38,6 +38,7 @@
   *  If you wish to discard the first row and use your own headers set to a `string[]` and set the `renameHeaders` option to `true`
   *  If you wish to transform the headers you can provide a transform function. 
       *  **NOTE** This will always rename the headers
+  * **NOTE** If headers either parsed, provided or transformed are NOT unique, then an error will be emitted and the stream will stop parsing.
 * `renameHeaders: {boolean} = false`: If you want the first line of the file to be removed and replaced by the one provided in the `headers` option. 
   * **NOTE** This option should only be used if the `headers` option is a `string[]`
   * **NOTE** If the `headers` option is a function then this option is always set to true.

--- a/examples/formatting/append.example.js
+++ b/examples/formatting/append.example.js
@@ -1,0 +1,61 @@
+const path = require('path');
+const fs = require('fs');
+const csv = require('../..');
+
+const write = (filestream, rows, options) => {
+    return new Promise((res, rej) => {
+        csv.writeToStream(filestream, rows, options)
+            .on('error', err => rej(err))
+            .on('finish', () => res());
+    });
+};
+
+// create a new csv
+const createCsv = (filePath, rows) => {
+    const csvFile = fs.createWriteStream(filePath);
+    return write(csvFile, rows, { headers: true, includeEndRowDelimiter: true });
+};
+
+// append the rows to the csv
+const appendToCsv = (filePath, rows = []) => {
+    const csvFile = fs.createWriteStream(filePath, { flags: 'a' });
+    // notice how headers are set to false
+    return write(csvFile, rows, { headers: false });
+};
+
+// read the file
+const readFile = filePath => {
+    return new Promise((res, rej) => {
+        fs.readFile(filePath, (err, contents) => {
+            if (err) {
+                return rej(err);
+            }
+            return res(contents);
+        });
+    });
+};
+
+const csvFilePath = path.resolve(__dirname, 'tmp', 'append.csv');
+
+// 1. create the csv
+createCsv(csvFilePath, [
+    { a: 'a1', b: 'b1', c: 'c1' },
+    { a: 'a2', b: 'b2', c: 'c2' },
+    { a: 'a3', b: 'b3', c: 'c3' },
+])
+    .then(() => {
+        // 2. append to the csv
+        return appendToCsv(csvFilePath, [
+            { a: 'a4', b: 'b4', c: 'c4' },
+            { a: 'a5', b: 'b5', c: 'c5' },
+            { a: 'a6', b: 'b6', c: 'c6' },
+        ]);
+    })
+    .then(() => readFile(csvFilePath))
+    .then(contents => {
+        console.log(`${contents}`);
+    })
+    .catch(err => {
+        console.error(err.stack);
+        process.exit(1);
+    });

--- a/examples/parsing/transform_headers.example.js
+++ b/examples/parsing/transform_headers.example.js
@@ -1,0 +1,15 @@
+const { EOL } = require('os');
+const csv = require('../../');
+
+const CSV_STRING = ['header1,header2', 'a1,b1', 'a2,b2'].join(EOL);
+
+const stream = csv
+    .parse({
+        headers: headers => headers.map(h => h.toUpperCase()),
+    })
+    .on('error', error => console.error(error))
+    .on('data', row => console.log(row))
+    .on('end', rowCount => console.log(`Parsed ${rowCount} rows`));
+
+stream.write(CSV_STRING);
+stream.end();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-csv",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-csv",
-  "version": "3.4.0",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -207,6 +207,15 @@
         "@types/lodash": "*"
       }
     },
+    "@types/lodash.groupby": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.groupby/-/lodash.groupby-4.6.6.tgz",
+      "integrity": "sha512-kwg3T7Ia63KtDNoQQR8hKrLHCAgrH4I44l5uEMuA6JCbj7DiSccaV4tNV1vbjtAOpX990SolVthJCmBVtRVRgw==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/lodash.isboolean": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.isboolean/-/lodash.isboolean-3.0.6.tgz",
@@ -265,6 +274,15 @@
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.partition/-/lodash.partition-4.6.6.tgz",
       "integrity": "sha512-s8ZNNFWhBgTKI4uNxVrTs3Aa7UQoi7Fesw55bfpBBMCLda+uSuwDyuax8ka9aBy8Ccsjp2SiS034DkSZa+CzVA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.uniq": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.uniq/-/lodash.uniq-4.5.6.tgz",
+      "integrity": "sha512-XHNMXBtiwsWZstZMyxOYjr0e8YYWv0RgPlzIHblTuwBBiWo2MzWVaTBihtBpslb5BglgAWIeBv69qt1+RTRW1A==",
       "dev": true,
       "requires": {
         "@types/lodash": "*"
@@ -2263,6 +2281,11 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
+    },
     "lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
@@ -2304,6 +2327,11 @@
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "log-driver": {
       "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "benchmark": "node ./benchmark",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
-  "files": ["build/src/**"],
+  "files": [
+    "build/src/**"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:C2FO/fast-csv.git"
@@ -40,6 +42,8 @@
     "@types/lodash.isstring": "^4.0.6",
     "@types/lodash.isundefined": "^3.0.6",
     "@types/lodash.partition": "^4.6.6",
+    "@types/lodash.uniq": "^4.5.6",
+    "@types/lodash.groupby": "^4.6.6",
     "@types/mocha": "^5.2.7",
     "@types/sinon": "^7.5.1",
     "@typescript-eslint/eslint-plugin": "^2.11.0",
@@ -66,11 +70,13 @@
   "dependencies": {
     "@types/node": "^12.12.17",
     "lodash.escaperegexp": "^4.1.2",
+    "lodash.groupby": "^4.6.0",
     "lodash.isboolean": "^3.0.3",
     "lodash.isequal": "^4.5.0",
     "lodash.isfunction": "^3.0.9",
     "lodash.isnil": "^4.0.0",
     "lodash.isstring": "^4.0.1",
-    "lodash.isundefined": "^3.0.1"
+    "lodash.isundefined": "^3.0.1",
+    "lodash.uniq": "^4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-csv",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "CSV parser and writer",
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",

--- a/src/formatter/CsvFormatterStream.ts
+++ b/src/formatter/CsvFormatterStream.ts
@@ -53,9 +53,16 @@ export default class CsvFormatterStream extends Transform {
     }
 
     public _flush(cb: TransformCallback): void {
-        if (this.formatterOptions.includeEndRowDelimiter) {
-            this.push(this.formatterOptions.rowDelimiter);
-        }
-        cb();
+        this.rowFormatter.finish((err, rows): void => {
+            if (err) {
+                return cb(err);
+            }
+            if (rows) {
+                rows.forEach((r): void => {
+                    this.push(Buffer.from(r, 'utf8'));
+                });
+            }
+            return cb();
+        });
     }
 }

--- a/src/formatter/FormatterOptions.ts
+++ b/src/formatter/FormatterOptions.ts
@@ -18,6 +18,7 @@ export interface FormatterOptionsArgs {
     includeEndRowDelimiter?: boolean;
     writeBOM?: boolean;
     transform?: RowTransformFunction;
+    alwaysWriteHeaders?: boolean;
 }
 
 export class FormatterOptions {
@@ -48,6 +49,8 @@ export class FormatterOptions {
     public readonly escapedQuote: string;
 
     public readonly BOM: string = '\ufeff';
+
+    public readonly alwaysWriteHeaders: boolean = false;
 
     public constructor(opts: FormatterOptionsArgs = {}) {
         Object.assign(this, opts || {});

--- a/src/formatter/formatter/RowFormatter.ts
+++ b/src/formatter/formatter/RowFormatter.ts
@@ -109,6 +109,21 @@ export default class RowFormatter {
         });
     }
 
+    public finish(cb: RowFormatterCallback): void {
+        const rows = [];
+        // check if we should write headers and we didnt get any rows
+        if (this.formatterOptions.alwaysWriteHeaders && this.rowCount === 0) {
+            if (!this.headers) {
+                return cb(new Error('`alwaysWriteHeaders` option is set to true but `headers` option not provided.'));
+            }
+            rows.push(this.formatColumns(this.headers, true));
+        }
+        if (this.formatterOptions.includeEndRowDelimiter) {
+            rows.push(this.formatterOptions.rowDelimiter);
+        }
+        return cb(null, rows);
+    }
+
     // check if we need to write header return true if we should also write a row
     // could be false if headers is true and the header row(first item) is passed in
     private checkHeaders(row: Row): { headers?: string[] | null; shouldFormatColumns: boolean } {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ export {
     SyncRowTransform as ParserSyncRowTransform,
     AsyncRowTransform as ParserAsyncRowTransform,
     RowTransformFunction as ParserRowTransformFunction,
+    HeaderArray as ParserHeaderArray,
+    HeaderTransformFunction as ParserHeaderTransformFunction,
 } from './parser';
 
 export const fromString = deprecate(parseString, 'csv.fromString has been deprecated in favor of csv.parseString');

--- a/src/parser/ParserOptions.ts
+++ b/src/parser/ParserOptions.ts
@@ -1,12 +1,13 @@
 import escapeRegExp from 'lodash.escaperegexp';
 import isNil from 'lodash.isnil';
+import { HeaderArray, HeaderTransformFunction } from './types';
 
 export interface ParserOptionsArgs {
     objectMode?: boolean;
     delimiter?: string;
     quote?: string | null;
     escape?: string;
-    headers?: boolean | (string | undefined | null)[];
+    headers?: boolean | HeaderTransformFunction | HeaderArray;
     renameHeaders?: boolean;
     ignoreEmpty?: boolean;
     comment?: string;
@@ -46,7 +47,7 @@ export class ParserOptions {
 
     public readonly trim: boolean = false;
 
-    public readonly headers: boolean | string[] | null = null;
+    public readonly headers: boolean | HeaderTransformFunction | HeaderArray | null = null;
 
     public readonly renameHeaders: boolean = false;
 

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -27,3 +27,6 @@ export type AsyncRowValidate = (row: Row, cb: RowValidateCallback) => void;
 export type RowValidate = AsyncRowValidate | SyncRowValidate;
 
 export const isSyncValidate = (validate: RowValidate): validate is SyncRowValidate => validate.length === 1;
+
+export type HeaderArray = (string | undefined | null)[];
+export type HeaderTransformFunction = (headers: HeaderArray) => HeaderArray;

--- a/test/formatter/CsvFormatterStream.test.ts
+++ b/test/formatter/CsvFormatterStream.test.ts
@@ -324,6 +324,80 @@ describe('CsvFormatterStream', () => {
         });
     });
 
+    describe('header option', () => {
+        it('should write an array of objects without headers', () =>
+            formatRows(objectRows, { headers: false }).then(formatted =>
+                assert.deepStrictEqual(formatted, ['a1,b1', '\na2,b2']),
+            ));
+
+        it('should write an array of objects with headers', () =>
+            formatRows(objectRows, { headers: true }).then(formatted =>
+                assert.deepStrictEqual(formatted, ['a,b', '\na1,b1', '\na2,b2']),
+            ));
+
+        it('should write an array of arrays without headers', () => {
+            const rows = [
+                ['a1', 'b1'],
+                ['a2', 'b2'],
+            ];
+            return formatRows(rows, { headers: false }).then(formatted =>
+                assert.deepStrictEqual(formatted, ['a1,b1', '\na2,b2']),
+            );
+        });
+
+        it('should write an array of arrays with headers', () =>
+            formatRows(arrayRows, { headers: true }).then(parsedCsv =>
+                assert.deepStrictEqual(parsedCsv, ['a,b', '\na1,b1', '\na2,b2']),
+            ));
+
+        it('should write an array of multi-dimensional arrays without headers', () =>
+            formatRows(multiDimensionalRows, { headers: false }).then(parsedCsv =>
+                assert.deepStrictEqual(parsedCsv, ['a1,b1', '\na2,b2']),
+            ));
+
+        it('should write an array of multi-dimensional arrays with headers', () =>
+            formatRows(multiDimensionalRows, { headers: true }).then(parsedCsv =>
+                assert.deepStrictEqual(parsedCsv, ['a,b', '\na1,b1', '\na2,b2']),
+            ));
+
+        it('should not write anything if headers are provided but no rows are provided', () =>
+            formatRows([], { headers: true }).then(parsedCsv => assert.deepStrictEqual(parsedCsv, [])));
+
+        describe('alwaysWriteHeaders option', () => {
+            it('should write the headers if rows are not provided', () => {
+                const headers = ['h1', 'h2'];
+                return formatRows([], { headers, alwaysWriteHeaders: true }).then(parsedCsv =>
+                    assert.deepStrictEqual(parsedCsv, [headers.join(',')]),
+                );
+            });
+
+            it('should write the headers ones if rows are provided', () => {
+                const headers = ['h1', 'h2'];
+                return formatRows(arrayRows, { headers, alwaysWriteHeaders: true }).then(parsedCsv =>
+                    assert.deepStrictEqual(parsedCsv, [headers.join(','), '\na,b', '\na1,b1', '\na2,b2']),
+                );
+            });
+
+            it('should fail if no headers are provided', () => {
+                return formatRows(arrayRows, { alwaysWriteHeaders: true }).catch(e =>
+                    assert.strictEqual(
+                        e.message,
+                        '`alwaysWriteHeaders` option is set to true but `headers` option not provided.',
+                    ),
+                );
+            });
+
+            it('should write the headers and an endRowDelimiter if includeEndRowDelimiter is true', () => {
+                const headers = ['h1', 'h2'];
+                return formatRows([], {
+                    headers,
+                    includeEndRowDelimiter: true,
+                    alwaysWriteHeaders: true,
+                }).then(parsedCsv => assert.deepStrictEqual(parsedCsv, [headers.join(','), '\n']));
+            });
+        });
+    });
+
     it('should add a final rowDelimiter if includeEndRowDelimiter is true', () =>
         formatRows(objectRows, { headers: true, includeEndRowDelimiter: true }).then(written =>
             assert.deepStrictEqual(written, ['a,b', '\na1,b1', '\na2,b2', '\n']),

--- a/test/formatter/FormatterOptions.test.ts
+++ b/test/formatter/FormatterOptions.test.ts
@@ -164,12 +164,22 @@ describe('FormatterOptions', () => {
     });
 
     describe('#writeBOM', () => {
-        it('should set includeEndRowDelimiter to false by default', () => {
+        it('should set writeBOM to false by default', () => {
             assert.strictEqual(createOptions().writeBOM, false);
         });
 
         it('should set to true if the writeBOM is specified', () => {
             assert.strictEqual(createOptions({ writeBOM: true }).writeBOM, true);
+        });
+    });
+
+    describe('#alwaysWriteHeaders', () => {
+        it('should set alwaysWriteHeaders to false by default', () => {
+            assert.strictEqual(createOptions().alwaysWriteHeaders, false);
+        });
+
+        it('should set to provided value if the alwaysWriteHeaders is specified', () => {
+            assert.strictEqual(createOptions({ alwaysWriteHeaders: true }).alwaysWriteHeaders, true);
         });
     });
 });

--- a/test/formatter/formatter/FieldFormatter.test.ts
+++ b/test/formatter/formatter/FieldFormatter.test.ts
@@ -3,109 +3,102 @@ import { FormatterOptionsArgs } from '../../../src';
 import { FormatterOptions, FieldFormatter } from '../../../src/formatter';
 
 describe('FieldFormatter', () => {
+    const createFormatter = (formatterOptions: FormatterOptionsArgs = {}) => {
+        return new FieldFormatter(new FormatterOptions(formatterOptions));
+    };
+
     describe('#format', () => {
-        const createFormatter = (formatterOptions: FormatterOptionsArgs = {}, headers?: string[]) => {
-            const formatter = new FieldFormatter(new FormatterOptions(formatterOptions));
-            if (headers) {
-                formatter.headers = headers;
-            }
-            return formatter;
-        };
-
-        const formatField = (field: string, fieldIndex: number, isHeader: boolean, fieldFormatter: FieldFormatter) =>
-            fieldFormatter.format(field, fieldIndex, isHeader);
-
         describe('header columns', () => {
             it('should return the field not quoted if it contains no quotes', () => {
                 const formatter = createFormatter();
-                assert.strictEqual(formatField('header', 0, true, formatter), 'header');
+                assert.strictEqual(formatter.format('header', 0, true), 'header');
             });
 
             it('should quote the field and escape quotes if it contains a quote character', () => {
                 const formatter = createFormatter();
-                assert.strictEqual(formatField('hea"d"er', 0, true, formatter), '"hea""d""er"');
+                assert.strictEqual(formatter.format('hea"d"er', 0, true), '"hea""d""er"');
             });
 
             it('should quote the field and if it contains a rowDelimiter', () => {
                 const formatter = createFormatter({ rowDelimiter: '\r\n' });
-                assert.strictEqual(formatField('hea\r\nder', 0, true, formatter), '"hea\r\nder"');
+                assert.strictEqual(formatter.format('hea\r\nder', 0, true), '"hea\r\nder"');
             });
 
             it('should quote the field if quoteHeaders is true', () => {
                 const formatter = createFormatter({ quoteHeaders: true });
-                assert.strictEqual(formatField('header', 0, true, formatter), '"header"');
+                assert.strictEqual(formatter.format('header', 0, true), '"header"');
             });
 
             it('should quote the header if quote headers is an array and the index of the header is true in the quoteHeaders array', () => {
                 const formatter = createFormatter({ quoteHeaders: [true] });
-                assert.strictEqual(formatField('header', 0, true, formatter), '"header"');
+                assert.strictEqual(formatter.format('header', 0, true), '"header"');
             });
 
             it('should not quote the header if quote headers is an array and the index of the header is false in the quoteHeaders array', () => {
                 const formatter = createFormatter({ quoteHeaders: [false] });
-                assert.strictEqual(formatField('header', 0, true, formatter), 'header');
+                assert.strictEqual(formatter.format('header', 0, true), 'header');
             });
 
             it('should quote the header if quoteHeaders is an object and quoteHeaders object has true for the column name', () => {
-                const formatter = createFormatter({ quoteHeaders: { header: true } }, ['header']);
-                assert.strictEqual(formatField('header', 0, true, formatter), '"header"');
+                const formatter = createFormatter({ quoteHeaders: { header: true }, headers: ['header'] });
+                assert.strictEqual(formatter.format('header', 0, true), '"header"');
             });
 
             it('should not quote the header if quoteHeaders is an object and quoteHeaders object has false for the column nam', () => {
-                const formatter = createFormatter({ quoteHeaders: { header: false } }, ['header']);
-                assert.strictEqual(formatField('header', 0, true, formatter), 'header');
+                const formatter = createFormatter({ quoteHeaders: { header: false }, headers: ['header'] });
+                assert.strictEqual(formatter.format('header', 0, true), 'header');
             });
 
             it('should not quote the header if quoteHeaders is an object and quoteHeaders object does not contain the header', () => {
-                const formatter = createFormatter({ quoteHeaders: { header2: true } }, ['header']);
-                assert.strictEqual(formatField('header', 0, true, formatter), 'header');
+                const formatter = createFormatter({ quoteHeaders: { header2: true }, headers: ['header'] });
+                assert.strictEqual(formatter.format('header', 0, true), 'header');
             });
         });
 
         describe('non-header columns', () => {
             it('should return the field not quoted if it contains no quotes', () => {
                 const formatter = createFormatter();
-                assert.strictEqual(formatField('col', 0, false, formatter), 'col');
+                assert.strictEqual(formatter.format('col', 0, false), 'col');
             });
 
             it('should quote the field and escape quotes if it contains a quote character', () => {
                 const formatter = createFormatter();
-                assert.strictEqual(formatField('c"o"l', 0, false, formatter), '"c""o""l"');
+                assert.strictEqual(formatter.format('c"o"l', 0, false), '"c""o""l"');
             });
 
             it('should quote the field if it contains a rowDelimiter', () => {
                 const formatter = createFormatter({ rowDelimiter: '\r\n' });
-                assert.strictEqual(formatField('col\r\n', 0, false, formatter), '"col\r\n"');
+                assert.strictEqual(formatter.format('col\r\n', 0, false), '"col\r\n"');
             });
 
             it('should quote the field if quoteColumns is true', () => {
                 const formatter = createFormatter({ quoteColumns: true });
-                assert.strictEqual(formatField('col', 0, false, formatter), '"col"');
+                assert.strictEqual(formatter.format('col', 0, false), '"col"');
             });
 
             it('should quote the header if quote headers is an array and the index of the header is true in the quoteColumns array', () => {
                 const formatter = createFormatter({ quoteColumns: [true] });
-                assert.strictEqual(formatField('col', 0, false, formatter), '"col"');
+                assert.strictEqual(formatter.format('col', 0, false), '"col"');
             });
 
             it('should not quote the header if quote headers is an array and the index of the header is false in the quoteColumns array', () => {
                 const formatter = createFormatter({ quoteColumns: [false] });
-                assert.strictEqual(formatField('col', 0, false, formatter), 'col');
+                assert.strictEqual(formatter.format('col', 0, false), 'col');
             });
 
             it('should quote the header if quoteColumns is an object and quoteColumns object has true for the column name', () => {
-                const formatter = createFormatter({ quoteColumns: { header: true } }, ['header']);
-                assert.strictEqual(formatField('col', 0, false, formatter), '"col"');
+                const formatter = createFormatter({ quoteColumns: { header: true }, headers: ['header'] });
+                assert.strictEqual(formatter.format('col', 0, false), '"col"');
             });
 
             it('should not quote the header if quoteColumns is an object and quoteColumns object has false for the column nam', () => {
-                const formatter = createFormatter({ quoteColumns: { header: false } }, ['header']);
-                assert.strictEqual(formatField('col', 0, false, formatter), 'col');
+                const formatter = createFormatter({ quoteColumns: { header: false }, headers: ['header'] });
+                assert.strictEqual(formatter.format('col', 0, false), 'col');
             });
 
             it('should not quote the header if quoteColumns is an object and quoteColumns object does not contain the header', () => {
-                const formatter = createFormatter({ quoteColumns: { header2: true } }, ['header']);
-                assert.strictEqual(formatField('col', 0, false, formatter), 'col');
+                const formatter = createFormatter({ quoteColumns: { header2: true }, headers: ['header'] });
+                assert.strictEqual(formatter.format('col', 0, false), 'col');
             });
         });
     });

--- a/test/issues/issue68.test.ts
+++ b/test/issues/issue68.test.ts
@@ -18,11 +18,7 @@ describe('Issue #68 - https://github.com/C2FO/fast-csv/issues/68', () => {
         d.run(() =>
             csv
                 .parseFile(path.resolve(__dirname, './assets/issue68-invalid.tsv'), { headers: true, delimiter: '\t' })
-                .on('data', () => null)
-                .on('end', (count: number) => {
-                    assert.strictEqual(count, 20000);
-                    throw new Error('End error');
-                }),
+                .on('data', () => null),
         );
     });
 

--- a/test/parser/CsvParsingStream.test.ts
+++ b/test/parser/CsvParsingStream.test.ts
@@ -233,6 +233,13 @@ describe('CsvParserStream', () => {
             stream.end();
         });
 
+        it('should propagate an error if headers are not unique', next => {
+            const stream = csv.parse({ headers: true });
+            listenForError(stream, 'Duplicate headers found ["first_name"]', next);
+            stream.write(assets.duplicateHeaders.content);
+            stream.end();
+        });
+
         it('should discard extra columns that do not map to a header when discardUnmappedColumns is true', () =>
             parseContentAndCollect(assets.headerColumnMismatch, { headers: true, discardUnmappedColumns: true }).then(
                 ({ count, rows }) => {

--- a/test/parser/ParserOptions.test.ts
+++ b/test/parser/ParserOptions.test.ts
@@ -149,6 +149,12 @@ describe('ParserOptions', () => {
             assert.deepStrictEqual(createOptions({ headers: ['1', '2', '3'] }).headers, ['1', '2', '3']);
         });
 
+        it('should accept a function', () => {
+            const opts = createOptions({ headers: headers => headers.map(h => h?.toLowerCase()) });
+            // @ts-ignore
+            assert.deepStrictEqual(opts.headers(['A', 'B', 'C']), ['a', 'b', 'c']);
+        });
+
         it('should accept headers as a boolean', () => {
             assert.deepStrictEqual(createOptions({ headers: true }).headers, true);
         });

--- a/test/parser/assets/duplicateHeaders.ts
+++ b/test/parser/assets/duplicateHeaders.ts
@@ -1,0 +1,13 @@
+import { resolve } from 'path';
+import { EOL } from 'os';
+
+export default {
+    path: resolve(__dirname, 'tmp', 'duplicate_header.csv'),
+
+    content: [
+        'first_name,first_name,email_address,address',
+        'First1,First1,email1@email.com,"1 Street St, State ST, 88888"',
+    ].join(EOL),
+
+    parsed: [],
+};

--- a/test/parser/assets/index.ts
+++ b/test/parser/assets/index.ts
@@ -13,6 +13,7 @@ import headerColumnMismatch from './headerColumnMismatch';
 import malformed from './malformed';
 import trailingComma from './trailingComma';
 import emptyRows from './emptyRows';
+import duplicateHeaders from './duplicateHeaders';
 
 export interface PathAndContent {
     path: string;
@@ -34,6 +35,7 @@ const write = (opts: PathAndContent): void => {
 export default {
     write,
     alternateEncoding,
+    duplicateHeaders,
     skipLines,
     withHeaders,
     withHeadersAndQuotes,

--- a/test/parser/transforms/HeaderTransformer.test.ts
+++ b/test/parser/transforms/HeaderTransformer.test.ts
@@ -65,6 +65,22 @@ describe('HeaderTransformer', () => {
                 });
         });
 
+        it('should skip the first row if headers is function and properly map the headers to the row', () => {
+            const row1 = ['origHeader1', 'origHeader2'];
+            const row2 = ['a', 'b'];
+            const transformer = createHeaderTransformer({
+                headers: headers => headers.map(h => h?.toUpperCase()),
+            });
+            return transform(row1, transformer)
+                .then(results => {
+                    assert.deepStrictEqual(results, { row: null, isValid: true });
+                    return transform(row2, transformer);
+                })
+                .then(results => {
+                    assert.deepStrictEqual(results, { row: { ORIGHEADER1: 'a', ORIGHEADER2: 'b' }, isValid: true });
+                });
+        });
+
         it('should throw an error if headers is not defined and renameHeaders is true', () => {
             const row1 = ['origHeader1', 'origHeader2'];
             const transformer = createHeaderTransformer({ renameHeaders: true });

--- a/test/parser/transforms/HeaderTransformer.test.ts
+++ b/test/parser/transforms/HeaderTransformer.test.ts
@@ -81,6 +81,28 @@ describe('HeaderTransformer', () => {
                 });
         });
 
+        it('should throw an error if headers is true and the first row is not unique', () => {
+            const row1 = ['origHeader1', 'origHeader1', 'origHeader2'];
+            const transformer = createHeaderTransformer({ headers: true });
+            return transform(row1, transformer).then(
+                () => assert.fail('should have failed'),
+                err => assert.strictEqual(err.message, 'Duplicate headers found ["origHeader1"]'),
+            );
+        });
+
+        it('should throw an error if headers is an array and is not unique', () => {
+            const headers = ['origHeader1', 'origHeader1', 'origHeader2'];
+            assert.throws(() => createHeaderTransformer({ headers }), /Duplicate headers found \["origHeader1"]/);
+        });
+
+        it('should throw an error if headers is a transform and returns non-unique values', () => {
+            const row = ['h1', 'h2', 'h3'];
+            const transformer = createHeaderTransformer({ headers: () => ['h1', 'h1', 'h3'] });
+            return transform(row, transformer).catch(err =>
+                assert.strictEqual(err.message, 'Duplicate headers found ["h1"]'),
+            );
+        });
+
         it('should throw an error if headers is not defined and renameHeaders is true', () => {
             const row1 = ['origHeader1', 'origHeader2'];
             const transformer = createHeaderTransformer({ renameHeaders: true });


### PR DESCRIPTION
* [ADDED] Ability to Transform Header #287
* [ADDED] Example require and import to README #301
* [ADDED] Added new formatting option `alwaysWriteHeaders` to always write headers even if no rows are provided #300
* [ADDED] Appending to csv example and docs #272
* [FIXED] Issue with duplicate headers causing dataloss, duplicate headers will can an error to be emitted. #276
* [FIXED] Issue where an error thrown while processing rows causes stream continue to parse, causing duplicate writes or swallowed exceptions.
