### PR TITLE
Added writeHeaders option

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+# v4.0.2
+
+* [ADDED] `writeHeaders` to `@fast-csv/format` option to prevent writing headers.
+    * This makes appending to a csv easier and safer because you can still specify headers without writing them.
+
 # v4.0.1
 
 * [FIXED] package.json homepage links

--- a/examples/formatting-js/examples/append.example.js
+++ b/examples/formatting-js/examples/append.example.js
@@ -2,56 +2,68 @@ const path = require('path');
 const fs = require('fs');
 const csv = require('@fast-csv/format');
 
-const write = (filestream, rows, options) => {
-    return new Promise((res, rej) => {
-        csv.writeToStream(filestream, rows, options)
-            .on('error', err => rej(err))
-            .on('finish', () => res());
-    });
-};
-
-// create a new csv
-const createCsv = (filePath, rows) => {
-    const csvFile = fs.createWriteStream(filePath);
-    return write(csvFile, rows, { headers: true, includeEndRowDelimiter: true });
-};
-
-// append the rows to the csv
-const appendToCsv = (filePath, rows = []) => {
-    const csvFile = fs.createWriteStream(filePath, { flags: 'a' });
-    // notice how headers are set to false
-    return write(csvFile, rows, { headers: false });
-};
-
-// read the file
-const readFile = filePath => {
-    return new Promise((res, rej) => {
-        fs.readFile(filePath, (err, contents) => {
-            if (err) {
-                return rej(err);
-            }
-            return res(contents);
+class CsvFile {
+    static write(filestream, rows, options) {
+        return new Promise((res, rej) => {
+            csv.writeToStream(filestream, rows, options)
+                .on('error', err => rej(err))
+                .on('finish', () => res());
         });
-    });
-};
+    }
 
-const csvFilePath = path.resolve(__dirname, 'append.tmp.csv');
+    constructor(opts) {
+        this.headers = opts.headers;
+        this.path = opts.path;
+        this.writeOpts = { headers: this.headers, includeEndRowDelimiter: true };
+    }
+
+    create(rows) {
+        return CsvFile.write(fs.createWriteStream(this.path), rows, { ...this.writeOpts });
+    }
+
+    append(rows) {
+        return CsvFile.write(fs.createWriteStream(this.path, { flags: 'a' }), rows, {
+            ...this.writeOpts,
+            // dont write the headers when appending
+            writeHeaders: false,
+        });
+    }
+
+    read() {
+        return new Promise((res, rej) => {
+            fs.readFile(this.path, (err, contents) => {
+                if (err) {
+                    return rej(err);
+                }
+                return res(contents);
+            });
+        });
+    }
+}
+
+const csvFile = new CsvFile({
+    path: path.resolve(__dirname, 'append.tmp.csv'),
+    // headers to write
+    headers: ['c', 'b', 'a'],
+});
 
 // 1. create the csv
-createCsv(csvFilePath, [
-    { a: 'a1', b: 'b1', c: 'c1' },
-    { a: 'a2', b: 'b2', c: 'c2' },
-    { a: 'a3', b: 'b3', c: 'c3' },
-])
-    .then(() => {
-        // 2. append to the csv
-        return appendToCsv(csvFilePath, [
+csvFile
+    .create([
+        { a: 'a1', b: 'b1', c: 'c1' },
+        { b: 'b2', a: 'a2', c: 'c2' },
+        { a: 'a3', b: 'b3', c: 'c3' },
+    ])
+    // append rows to file
+    .then(() =>
+        csvFile.append([
             { a: 'a4', b: 'b4', c: 'c4' },
             { a: 'a5', b: 'b5', c: 'c5' },
-            { a: 'a6', b: 'b6', c: 'c6' },
-        ]);
-    })
-    .then(() => readFile(csvFilePath))
+        ]),
+    )
+    // append another row
+    .then(() => csvFile.append([{ a: 'a6', b: 'b6', c: 'c6' }]))
+    .then(() => csvFile.read())
     .then(contents => {
         console.log(`${contents}`);
     })
@@ -61,10 +73,10 @@ createCsv(csvFilePath, [
     });
 
 // Output:
-// a,b,c
-// a1,b1,c1
-// a2,b2,c2
-// a3,b3,c3
-// a4,b4,c4
-// a5,b5,c5
-// a6,b6,c6
+// c,b,a
+// c1,b1,a1
+// c2,b2,a2
+// c3,b3,a3
+// c4,b4,a4
+// c5,b5,a5
+// c6,b6,a6

--- a/examples/formatting-js/examples/write_headers_auto_discover.example.js
+++ b/examples/formatting-js/examples/write_headers_auto_discover.example.js
@@ -1,0 +1,17 @@
+const csv = require('@fast-csv/format');
+
+const csvStream = csv.format({ headers: true, writeHeaders: false });
+
+csvStream.pipe(process.stdout).on('end', process.exit);
+
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.end();
+
+// Output:
+// value1a,value2a
+// value1a,value2a
+// value1a,value2a
+// value1a,value2a

--- a/examples/formatting-js/examples/write_headers_provided_headers.example.js
+++ b/examples/formatting-js/examples/write_headers_provided_headers.example.js
@@ -1,0 +1,17 @@
+const csv = require('@fast-csv/format');
+
+const csvStream = csv.format({ headers: ['header2', 'header1'], writeHeaders: false });
+
+csvStream.pipe(process.stdout).on('end', process.exit);
+
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.end();
+
+// Output:
+// value2a,value1a
+// value2a,value1a
+// value2a,value1a
+// value2a,value1a

--- a/examples/formatting-ts/examples/append.example.ts
+++ b/examples/formatting-ts/examples/append.example.ts
@@ -2,67 +2,92 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { FormatterOptionsArgs, Row, writeToStream } from '@fast-csv/format';
 
-const write = (stream: NodeJS.WritableStream, rows: Row[], options: FormatterOptionsArgs<Row, Row>): Promise<void> => {
-    return new Promise((res, rej) => {
-        writeToStream(stream, rows, options)
-            .on('error', err => rej(err))
-            .on('finish', () => res());
-    });
+type CsvFileOpts = {
+    headers: string[];
+    path: string;
 };
 
-// create a new csv
-const createCsv = (filePath: string, rows: Row[]): Promise<void> => {
-    const csvFile = fs.createWriteStream(filePath);
-    return write(csvFile, rows, { headers: true, includeEndRowDelimiter: true });
-};
-
-// append the rows to the csv
-const appendToCsv = (filePath: string, rows: Row[] = []): Promise<void> => {
-    const csvFile = fs.createWriteStream(filePath, { flags: 'a' });
-    // notice how headers are set to false
-    return write(csvFile, rows, { headers: false });
-};
-
-// read the file
-const readFile = (filePath: string): Promise<Buffer> => {
-    return new Promise((res, rej) => {
-        fs.readFile(filePath, (err, contents) => {
-            if (err) {
-                return rej(err);
-            }
-            return res(contents);
+class CsvFile {
+    static write(stream: NodeJS.WritableStream, rows: Row[], options: FormatterOptionsArgs<Row, Row>): Promise<void> {
+        return new Promise((res, rej) => {
+            writeToStream(stream, rows, options)
+                .on('error', (err: Error) => rej(err))
+                .on('finish', () => res());
         });
-    });
-};
+    }
 
-const csvFilePath = path.resolve(__dirname, 'append.csv');
+    private readonly headers: string[];
+
+    private readonly path: string;
+
+    private readonly writeOpts: FormatterOptionsArgs<Row, Row>;
+
+    constructor(opts: CsvFileOpts) {
+        this.headers = opts.headers;
+        this.path = opts.path;
+        this.writeOpts = { headers: this.headers, includeEndRowDelimiter: true };
+    }
+
+    create(rows: Row[]): Promise<void> {
+        return CsvFile.write(fs.createWriteStream(this.path), rows, { ...this.writeOpts });
+    }
+
+    append(rows: Row[]): Promise<void> {
+        return CsvFile.write(fs.createWriteStream(this.path, { flags: 'a' }), rows, {
+            ...this.writeOpts,
+            // dont write the headers when appending
+            writeHeaders: false,
+        } as FormatterOptionsArgs<Row, Row>);
+    }
+
+    read(): Promise<Buffer> {
+        return new Promise((res, rej) => {
+            fs.readFile(this.path, (err, contents) => {
+                if (err) {
+                    return rej(err);
+                }
+                return res(contents);
+            });
+        });
+    }
+}
+
+const csvFile = new CsvFile({
+    path: path.resolve(__dirname, 'append.tmp.csv'),
+    // headers to write
+    headers: ['c', 'b', 'a'],
+});
 
 // 1. create the csv
-createCsv(csvFilePath, [
-    { a: 'a1', b: 'b1', c: 'c1' },
-    { a: 'a2', b: 'b2', c: 'c2' },
-    { a: 'a3', b: 'b3', c: 'c3' },
-])
-    // 2. append to the csv
+csvFile
+    .create([
+        { a: 'a1', b: 'b1', c: 'c1' },
+        { b: 'b2', a: 'a2', c: 'c2' },
+        { a: 'a3', b: 'b3', c: 'c3' },
+    ])
+    // append rows to file
     .then(() =>
-        appendToCsv(csvFilePath, [
+        csvFile.append([
             { a: 'a4', b: 'b4', c: 'c4' },
             { a: 'a5', b: 'b5', c: 'c5' },
-            { a: 'a6', b: 'b6', c: 'c6' },
         ]),
     )
-    .then(() => readFile(csvFilePath))
-    .then(contents => console.log(`${contents}`))
+    // append another row
+    .then(() => csvFile.append([{ a: 'a6', b: 'b6', c: 'c6' }]))
+    .then(() => csvFile.read())
+    .then(contents => {
+        console.log(`${contents}`);
+    })
     .catch(err => {
         console.error(err.stack);
         process.exit(1);
     });
 
 // Output:
-// a,b,c
-// a1,b1,c1
-// a2,b2,c2
-// a3,b3,c3
-// a4,b4,c4
-// a5,b5,c5
-// a6,b6,c6
+// c,b,a
+// c1,b1,a1
+// c2,b2,a2
+// c3,b3,a3
+// c4,b4,a4
+// c5,b5,a5
+// c6,b6,a6

--- a/examples/formatting-ts/examples/write_headers_auto_discover.example.ts
+++ b/examples/formatting-ts/examples/write_headers_auto_discover.example.ts
@@ -1,0 +1,17 @@
+import { format } from '@fast-csv/format';
+
+const csvStream = format({ headers: true, writeHeaders: false });
+
+csvStream.pipe(process.stdout).on('end', process.exit);
+
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.end();
+
+// Output:
+// value1a,value2a
+// value1a,value2a
+// value1a,value2a
+// value1a,value2a

--- a/examples/formatting-ts/examples/write_headers_provided_headers.example.ts
+++ b/examples/formatting-ts/examples/write_headers_provided_headers.example.ts
@@ -1,0 +1,17 @@
+import { format } from '@fast-csv/format';
+
+const csvStream = format({ headers: ['header2', 'header1'], writeHeaders: false });
+
+csvStream.pipe(process.stdout).on('end', process.exit);
+
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.write({ header1: 'value1a', header2: 'value2a' });
+csvStream.end();
+
+// Output:
+// value2a,value1a
+// value2a,value1a
+// value2a,value1a
+// value2a,value1a

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,5 @@
 {
+  "tagVersionPrefix": "v",
   "packages": [
     "examples/*",
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "clean": "lerna run clean",
     "build": "lerna run build",
     "pub": "lerna publish from-git",
-    "version": "npx lerna version --tag-version-prefix=v",
+    "version": "npx lerna version",
     "test": "npm run lint && npm run jest && npm run examples",
     "lint": "eslint --ext=.ts,.js .",
     "jest": "jest --coverage",

--- a/packages/format/README.md
+++ b/packages/format/README.md
@@ -58,6 +58,10 @@ import * as format csv '@fast-csv/format';
   *  If there is not a headers row and you want to provide one then set to a `string[]`
       * **NOTE** If the row is an object the headers must match fields in the object, otherwise you will end up with empty fields
       * **NOTE** If there are more headers than columns then additional empty columns will be added
+* `writeHeaders: {boolean} = true`: Set to false you dont want to write headers.
+  * If `headers` is set to `true` and `writeHeaders` is `false` then any auto discovered headers will not be written in the output.
+  * If `headers` is an `array` and `writeHeaders` is `false` then they will not be written.  
+  * **NOTE** This is can be used to append to an existing csv.
 * `alwaysWriteHeaders: {boolean} = false`: Set to true if you always want headers written, even if no rows are written.
   * **NOTE** This will throw an error if headers are not specified as an array.
 * `quoteColumns: {boolean|boolean[]|{[string]: boolean} = false`

--- a/packages/format/__tests__/FormatterOptions.spec.ts
+++ b/packages/format/__tests__/FormatterOptions.spec.ts
@@ -141,6 +141,40 @@ describe('FormatterOptions', () => {
         });
     });
 
+    describe('#shouldWriteHeaders', () => {
+        it('should set to true if headers is true', () => {
+            expect(createOptions({ headers: true }).shouldWriteHeaders).toBe(true);
+        });
+
+        it('should set to false if headers is true and writeHeaders is false', () => {
+            expect(createOptions({ headers: true, writeHeaders: false }).shouldWriteHeaders).toBe(false);
+        });
+
+        it('should set to true if headers is true and writeHeaders is true', () => {
+            expect(createOptions({ headers: true, writeHeaders: true }).shouldWriteHeaders).toBe(true);
+        });
+
+        it('should set to true if headers is an array', () => {
+            expect(createOptions({ headers: ['h1', 'h2'] }).shouldWriteHeaders).toBe(true);
+        });
+
+        it('should set to false if headers is an array and writeHeaders is false', () => {
+            expect(createOptions({ headers: ['h1', 'h2'], writeHeaders: false }).shouldWriteHeaders).toBe(false);
+        });
+
+        it('should set to true if headers is an array and writeHeaders is true', () => {
+            expect(createOptions({ headers: ['h1', 'h2'], writeHeaders: true }).shouldWriteHeaders).toBe(true);
+        });
+
+        it('should set to false if headers is not defined', () => {
+            expect(createOptions({}).shouldWriteHeaders).toBe(false);
+        });
+
+        it('should set to false if headers is not defined and writeHeaders is true', () => {
+            expect(createOptions({ writeHeaders: true }).shouldWriteHeaders).toBe(false);
+        });
+    });
+
     describe('#includeEndRowDelimiter', () => {
         it('should set includeEndRowDelimiter to false by default', () => {
             expect(createOptions().includeEndRowDelimiter).toBe(false);

--- a/packages/format/__tests__/formatter/RowFormatter.spec.ts
+++ b/packages/format/__tests__/formatter/RowFormatter.spec.ts
@@ -279,12 +279,22 @@ describe('RowFormatter', () => {
                         const formatter = createFormatter({ headers: true });
                         await expect(formatRow(row, formatter)).resolves.toEqual(['a,b', '\na1,b1']);
                     });
+
+                    it('should not write the first row if writeHeaders is false', async () => {
+                        const formatter = createFormatter({ headers: true, writeHeaders: false });
+                        await expect(formatRow(row, formatter)).resolves.toEqual(['a1,b1']);
+                    });
                 });
 
                 describe('with headers provided', () => {
-                    it('should the new headers and the row', async () => {
+                    it('should write the provided headers and the row', async () => {
                         const formatter = createFormatter({ headers: ['a', 'b'] });
                         await expect(formatRow(row, formatter)).resolves.toEqual(['a,b', '\na1,b1']);
+                    });
+
+                    it('should not write the header row if writeHeaders is false', async () => {
+                        const formatter = createFormatter({ headers: ['a', 'b'], writeHeaders: false });
+                        await expect(formatRow(row, formatter)).resolves.toEqual(['a1,b1']);
                     });
 
                     it('should respect the order of the columns', async () => {
@@ -295,6 +305,11 @@ describe('RowFormatter', () => {
                     it('should append an additional column for new fields', async () => {
                         const formatter = createFormatter({ headers: ['a', 'b', 'no_field'] });
                         await expect(formatRow(row, formatter)).resolves.toEqual(['a,b,no_field', '\na1,b1,']);
+                    });
+
+                    it('should respect the order of the columns and not write the headers if writeHeaders is false', async () => {
+                        const formatter = createFormatter({ headers: ['b', 'a'], writeHeaders: false });
+                        await expect(formatRow(row, formatter)).resolves.toEqual(['b1,a1']);
                     });
                 });
             });

--- a/packages/format/src/FormatterOptions.ts
+++ b/packages/format/src/FormatterOptions.ts
@@ -15,6 +15,7 @@ export interface FormatterOptionsArgs<I extends Row, O extends Row> {
     quoteColumns?: QuoteColumns;
     quoteHeaders?: QuoteColumns;
     headers?: null | boolean | string[];
+    writeHeaders?: boolean;
     includeEndRowDelimiter?: boolean;
     writeBOM?: boolean;
     transform?: RowTransformFunction<I, O>;
@@ -66,7 +67,7 @@ export class FormatterOptions<I extends Row, O extends Row> {
         if (typeof opts?.escape !== 'string') {
             this.escape = this.quote;
         }
-        this.shouldWriteHeaders = !!this.headers;
+        this.shouldWriteHeaders = !!this.headers && (opts.writeHeaders ?? true);
         this.headers = Array.isArray(this.headers) ? this.headers : null;
         this.escapedQuote = `${this.escape}${this.quote}`;
     }

--- a/packages/format/src/formatter/RowFormatter.ts
+++ b/packages/format/src/formatter/RowFormatter.ts
@@ -135,7 +135,7 @@ export class RowFormatter<I extends Row, O extends Row> {
         this.fieldFormatter.headers = headers;
         if (!this.shouldWriteHeaders) {
             // if we are not supposed to write the headers then
-            // alwyas format the columns
+            // always format the columns
             return { shouldFormatColumns: true, headers: null };
         }
         // if the row is equal to headers dont format


### PR DESCRIPTION
* [ADDED] `writeHeaders` to `@fast-csv/format` option to prevent writing headers.
    * This makes appending to a csv easier and safer because you can still specify headers without writing them.