### PR TITLE
V4.0.3

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 * [FIXED] Issue where invalid rows were not accounted for when skipRows was set [#317](https://github.com/C2FO/fast-csv/issues/317)
 * [FIXED] Issue where readableObjectMode was not set to false when formatting [#319](https://github.com/C2FO/fast-csv/issues/319)
+* [FIXED] Issue where carriage returns and line feeds were not always quoted when formatting [#320](https://github.com/C2FO/fast-csv/issues/320)
 
 # v4.0.2
 

--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+# v4.0.3
+
+* [FIXED] Issue where invalid rows were not accounted for when skipRows was set [#317](https://github.com/C2FO/fast-csv/issues/317)
+
 # v4.0.2
 
 * [ADDED] `writeHeaders` to `@fast-csv/format` option to prevent writing headers.

--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 # v4.0.3
 
 * [FIXED] Issue where invalid rows were not accounted for when skipRows was set [#317](https://github.com/C2FO/fast-csv/issues/317)
+* [FIXED] Issue where readableObjectMode was not set to false when formatting [#319](https://github.com/C2FO/fast-csv/issues/319)
 
 # v4.0.2
 

--- a/packages/format/__tests__/formatter/FieldFormatter.spec.ts
+++ b/packages/format/__tests__/formatter/FieldFormatter.spec.ts
@@ -23,6 +23,24 @@ describe('FieldFormatter', () => {
                 expect(formatter.format('hea\r\nder', 0, true)).toEqual('"hea\r\nder"');
             });
 
+            it('should quote the field and if it contains a CR', () => {
+                // set row delimiter to something else to ensure it will still quote
+                const formatter = createFormatter({ rowDelimiter: '#' });
+                expect(formatter.format('hea\rder', 0, true)).toEqual('"hea\rder"');
+            });
+
+            it('should quote the field and if it contains a LF', () => {
+                // set row delimiter to something else to ensure it will still quote
+                const formatter = createFormatter({ rowDelimiter: '#' });
+                expect(formatter.format('hea\nder', 0, true)).toEqual('"hea\nder"');
+            });
+
+            it('should quote the field and if it contains a CRLF', () => {
+                // set row delimiter to something else to ensure it will still quote
+                const formatter = createFormatter({ rowDelimiter: '#' });
+                expect(formatter.format('hea\r\nder', 0, true)).toEqual('"hea\r\nder"');
+            });
+
             it('should quote the field if quoteHeaders is true', () => {
                 const formatter = createFormatter({ quoteHeaders: true });
                 expect(formatter.format('header', 0, true)).toEqual('"header"');

--- a/packages/format/src/CsvFormatterStream.ts
+++ b/packages/format/src/CsvFormatterStream.ts
@@ -11,7 +11,7 @@ export class CsvFormatterStream<I extends Row, O extends Row> extends Transform 
     private hasWrittenBOM = false;
 
     public constructor(formatterOptions: FormatterOptions<I, O>) {
-        super({ objectMode: formatterOptions.objectMode });
+        super({ writableObjectMode: formatterOptions.objectMode });
         this.formatterOptions = formatterOptions;
         this.rowFormatter = new RowFormatter(formatterOptions);
         // if writeBOM is false then set to true

--- a/packages/format/src/formatter/FieldFormatter.ts
+++ b/packages/format/src/formatter/FieldFormatter.ts
@@ -19,7 +19,7 @@ export class FieldFormatter<I extends Row, O extends Row> {
             this.headers = formatterOptions.headers;
         }
         this.REPLACE_REGEXP = new RegExp(formatterOptions.quote, 'g');
-        const escapePattern = `[${formatterOptions.delimiter}${escapeRegExp(formatterOptions.rowDelimiter)}']`;
+        const escapePattern = `[${formatterOptions.delimiter}${escapeRegExp(formatterOptions.rowDelimiter)}|\r|\n']`;
         this.ESCAPE_REGEXP = new RegExp(escapePattern);
     }
 

--- a/packages/parse/__tests__/CsvParsingStream.spec.ts
+++ b/packages/parse/__tests__/CsvParsingStream.spec.ts
@@ -369,6 +369,21 @@ describe('CsvParserStream', () => {
                     expected,
                 );
             });
+
+            describe('strict column handling', () => {
+                it('should include the invalid rows when counting rows to skip', async () => {
+                    const expectedRows = withHeadersAndMissingColumns.parsed;
+                    await expectParsed(
+                        parseContentAndCollect(withHeadersAndMissingColumns, {
+                            headers: true,
+                            strictColumnHandling: true,
+                            skipRows: 2,
+                        }),
+                        expectedRows.slice(-1),
+                        [],
+                    );
+                });
+            });
         });
 
         describe('without headers', () => {

--- a/packages/parse/__tests__/issues/issue317.spec.ts
+++ b/packages/parse/__tests__/issues/issue317.spec.ts
@@ -1,0 +1,29 @@
+import { EOL } from 'os';
+import { parseString, RowMap, RowArray } from '../../src';
+
+describe('Issue #317 - https://github.com/C2FO/fast-csv/issues/317', () => {
+    const CSV_CONTENT = ['header1,header2', 'col1', 'col2,col2', 'col3', 'col4,col4', 'col5,col5', 'col6,col6'].join(
+        EOL,
+    );
+    const expectedInvalidRows = [['col3']];
+    const expectedRows = [
+        { header1: 'col4', header2: 'col4' },
+        { header1: 'col5', header2: 'col5' },
+        { header1: 'col6', header2: 'col6' },
+    ];
+
+    it('skip trailing whitespace after a quoted field', done => {
+        const invalid: RowArray[] = [];
+        const rows: RowMap[] = [];
+        parseString(CSV_CONTENT, { headers: true, skipRows: 2, strictColumnHandling: true, maxRows: 4 })
+            .on('data-invalid', (row: RowArray) => invalid.push(row))
+            .on('data', (r: RowMap) => rows.push(r))
+            .on('error', done)
+            .on('end', (count: number) => {
+                expect(rows).toEqual(expectedRows);
+                expect(invalid).toEqual(expectedInvalidRows);
+                expect(count).toBe(expectedRows.length + invalid.length);
+                done();
+            });
+    });
+});


### PR DESCRIPTION
* [FIXED] Issue where invalid rows were not accounted for when skipRows was set #317
* [FIXED] Issue where readableObjectMode was not set to false when formatting #319
* [FIXED] Issue where carriage returns and line feeds were not always quoted when formatting #320
