### PR TITLE
Pass errors through callbacks

### DIFF
--- a/packages/parse/src/CsvParserStream.ts
+++ b/packages/parse/src/CsvParserStream.ts
@@ -82,7 +82,7 @@ export class CsvParserStream<I extends Row, O extends Row> extends Transform {
             const rows = this.parse(newLine, true);
             return this.processRows(rows, done);
         } catch (e) {
-            return this.destroy(e);
+            return done(e);
         }
     }
 
@@ -114,7 +114,7 @@ export class CsvParserStream<I extends Row, O extends Row> extends Transform {
         const iterate = (i: number): void => {
             const callNext = (err?: Error): void => {
                 if (err) {
-                    return this.destroy(err);
+                    return cb(err);
                 }
                 if (i % 100 === 0) {
                     // incase the transform are sync insert a next tick to prevent stack overflow


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/c2fo/fast-csv/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

When an error within the parsing is detected, the stream that started the parsing can be destroyed in some instances. This makes an assumption that users want the file stream destroyed when an error is encountered.

Rather than destroying the stream, pass the error through the regular callback structure.

This resolves #397 