### PR TITLE
Make @types/node a dev dependency

### DIFF
--- a/packages/fast-csv/package.json
+++ b/packages/fast-csv/package.json
@@ -38,7 +38,9 @@
   },
   "dependencies": {
     "@fast-csv/format": "4.3.1",
-    "@fast-csv/parse": "4.3.1",
+    "@fast-csv/parse": "4.3.1"
+  },
+  "devDependencies": {
     "@types/node": "^14.0.1"
   }
 }


### PR DESCRIPTION
@types/node is getting installed as a dependency, which isn't necessary, and ends up adding extra 700kb to install size.

I'm assuming this is just an oversight. I didn't create tests because there's no direct references to the types, and I can't imagine how this change would break things. It works for me locally after deleting it from node_modules

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/c2fo/fast-csv/pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?