### PR TITLE
Update text in the caution block about the strictColumnHandling option.

### DIFF
--- a/documentation/docs/parsing/options.md
+++ b/documentation/docs/parsing/options.md
@@ -60,7 +60,7 @@ If your rows are arrays, and you wan to skip certain columns you can provide a s
 When setting the headers option to a function it will always rename the headers 
 :::
 :::caution
-If you specify headers and there are more columns than headers an error **WILL NOT** be emitted unless `strictColumnHandling` is set to `true` 
+If you specify headers and there are more columns than headers an error **WILL ONLY** be emitted if `strictColumnHandling` is set to `false` 
 :::
 :::warning
 If headers either parsed, provided or transformed are NOT unique, then an error will be emitted and the stream will stop parsing.


### PR DESCRIPTION
Hi, thank you for this amazing library, it helps me a lot in work.
I think it would be easier to understand the *strictColumnHandling* option if you change the caution text block about it. Actually it has some **anti-negative** structures that I think can be difficult to understand.

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/c2fo/fast-csv/pulls) for the same update/change?