### PR TITLE
Update getting-started.md to fix the installation link

### DIFF
--- a/documentation/docs/introduction/getting-started.md
+++ b/documentation/docs/introduction/getting-started.md
@@ -16,7 +16,7 @@ Fast-csv is library for parsing and formatting CSVs or any other delimited value
 
 ## Install 
 
-See [installation docs](./install)
+See [installation docs](../install)
 
 ## Packages
 


### PR DESCRIPTION
The installation link is pointing to `https://c2fo.io/fast-csv/docs/introduction/getting-started/install` which gives 404 error. Instead, the actual installation link is `https://c2fo.io/fast-csv/docs/introduction/install`

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/c2fo/fast-csv/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Have you added tests for the new feature
2. [ ] Does your submission pass tests?
3. [ ] Have you lint your code locally prior to submission?
4. [ ] Have you updated the docs?
    * [ ] If you added new parsing or formatting options have you added them to the docs?
    * [ ] If applicable have you added an example to the parsing or formatting docs? 

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?