### PR TITLE
fix(formatter,#503): Do not ignore rows when headers is false

### DIFF
--- a/documentation/docs/formatting/options.md
+++ b/documentation/docs/formatting/options.md
@@ -58,9 +58,9 @@ Set to `true` if you want the first character written to the stream to be a utf-
 **Type**: `null|boolean|string[]` **Default**: `null`
 
 If `true` then the headers will be auto detected from the first row. [Example](./examples.mdx#auto-discovery)
-    * If the row is a one-dimensional array then headers is a no-op
-    * If the row is an object then the keys will be used.
-    * If the row is an array of two element arrays (`[ ['header', 'column'], ['header2', 'column2'] ]`) then the first element in each array will be used.
+* If the row is a one-dimensional array then the `headers` will be the first row processed
+* If the row is an object then the keys will be used.
+* If the row is an array of two element arrays (`[ ['header', 'column'], ['header2', 'column2'] ]`) then the first element in each array will be used.
 
 If there is not a headers row and you want to provide one then set to a `string[]`. [Example](./examples.mdx#provided-headers)
 

--- a/packages/format/__tests__/formatter/RowFormatter.spec.ts
+++ b/packages/format/__tests__/formatter/RowFormatter.spec.ts
@@ -93,6 +93,12 @@ describe('RowFormatter', () => {
                         const formatter = createFormatter({ headers: false });
                         await expect(formatRow(headerRow, formatter)).resolves.toEqual([headerRow.join(',')]);
                     });
+
+                    it('should still format all rows without headers', async () => {
+                        const formatter = createFormatter({ headers: false });
+                        await expect(formatRow([], formatter)).resolves.toEqual(['']);
+                        await expect(formatRow(headerRow, formatter)).resolves.toEqual([`\n${headerRow.join(',')}`]);
+                    });
                 });
 
                 describe('with headers=true', () => {

--- a/packages/format/__tests__/issues/issue503.spec.ts
+++ b/packages/format/__tests__/issues/issue503.spec.ts
@@ -1,0 +1,34 @@
+import { RecordingStream } from '../__fixtures__';
+import { RowArray, write } from '../../src';
+
+describe('Issue #503 - https://github.com/C2FO/fast-csv/issues/503', () => {
+    it('should emit all columns after an empty row', () => {
+        return new Promise((res, rej) => {
+            const rs = new RecordingStream();
+            const data: RowArray[] = [[], ['something']];
+
+            write(data, { quote: false, headers: false, writeHeaders: false })
+                .pipe(rs)
+                .on('error', rej)
+                .on('finish', () => {
+                    expect(rs.data).toEqual(['\nsomething']);
+                    res();
+                });
+        });
+    });
+
+    it('should not assume first row is a header if header = false', () => {
+        return new Promise((res, rej) => {
+            const rs = new RecordingStream();
+            const data: RowArray[] = [['1'], [], ['1', '2', '3']];
+
+            write(data, { quote: false, headers: false, writeHeaders: false })
+                .pipe(rs)
+                .on('error', rej)
+                .on('finish', () => {
+                    expect(rs.data).toEqual(['1', '\n', '\n1,2,3']);
+                    res();
+                });
+        });
+    });
+});


### PR DESCRIPTION
* Fixes issue where row contents were ignored if the first row is empty and headers is false

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/c2fo/fast-csv/pulls) for the same update/change?
