### PR TITLE
Added missing single quote in error message

### DIFF
--- a/packages/parse/__tests__/CsvParsingStream.spec.ts
+++ b/packages/parse/__tests__/CsvParsingStream.spec.ts
@@ -479,7 +479,7 @@ describe('CsvParserStream', () => {
         return new Promise((res, rej) => {
             write(malformed);
             const stream = parseFile(malformed.path, { headers: true });
-            expectErrorEvent(stream, "Parse Error: expected: ',' OR new line got: 'a'. at 'a   \", Las", res, rej);
+            expectErrorEvent(stream, "Parse Error: expected: ',' OR new line got: 'a'. at 'a   \'", Las", res, rej);
         });
     });
 

--- a/packages/parse/__tests__/CsvParsingStream.spec.ts
+++ b/packages/parse/__tests__/CsvParsingStream.spec.ts
@@ -479,7 +479,7 @@ describe('CsvParserStream', () => {
         return new Promise((res, rej) => {
             write(malformed);
             const stream = parseFile(malformed.path, { headers: true });
-            expectErrorEvent(stream, "Parse Error: expected: ',' OR new line got: 'a'. at 'a   '\", Las", res, rej);
+            expectErrorEvent(stream, "Parse Error: expected: ',' OR new line got: 'a'. at 'a   \", Las'", res, rej);
         });
     });
 

--- a/packages/parse/__tests__/CsvParsingStream.spec.ts
+++ b/packages/parse/__tests__/CsvParsingStream.spec.ts
@@ -479,7 +479,7 @@ describe('CsvParserStream', () => {
         return new Promise((res, rej) => {
             write(malformed);
             const stream = parseFile(malformed.path, { headers: true });
-            expectErrorEvent(stream, "Parse Error: expected: ',' OR new line got: 'a'. at 'a   \'", Las", res, rej);
+            expectErrorEvent(stream, "Parse Error: expected: ',' OR new line got: 'a'. at 'a   '\", Las", res, rej);
         });
     });
 

--- a/packages/parse/src/parser/column/QuotedColumnParser.ts
+++ b/packages/parse/src/parser/column/QuotedColumnParser.ts
@@ -98,7 +98,7 @@ export class QuotedColumnParser {
                 // tldr: only part of the column was quoted
                 const linePreview = scanner.lineFromCursor.substr(0, 10).replace(/[\r\n]/g, "\\n'");
                 throw new Error(
-                    `Parse Error: expected: '${parserOptions.escapedDelimiter}' OR new line got: '${nextNonSpaceToken.token}'. at '${linePreview}`,
+                    `Parse Error: expected: '${parserOptions.escapedDelimiter}' OR new line got: '${nextNonSpaceToken.token}'. at '${linePreview}'`,
                 );
             }
             scanner.advanceToToken(nextNonSpaceToken);


### PR DESCRIPTION
Without the extra quotation mark, you can not know if the first quotation mark is part of the problem or part of the error message. Issue: #569