### PR TITLE
Fix linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,8 +18,7 @@ module.exports = {
         'plugin:@typescript-eslint/recommended-requiring-type-checking',
         'plugin:jest/recommended',
         'plugin:jest/style',
-        'prettier',
-        'prettier/@typescript-eslint',
+        'plugin:prettier/recommended',
     ],
     ignorePatterns: ['**/build', '**/node_modules', 'documentation'],
     rules: {
@@ -38,6 +37,16 @@ module.exports = {
             rules: {
                 '@typescript-eslint/explicit-function-return-type': 'off',
                 '@typescript-eslint/ban-ts-comment': 'off',
+            },
+        },
+        {
+            files: ['*.example.ts'],
+            rules: {
+                '@typescript-eslint/no-unsafe-assignment': 'off',
+                '@typescript-eslint/no-unsafe-member-access': 'off',
+                '@typescript-eslint/no-unsafe-call': 'off',
+                '@typescript-eslint/no-unsafe-return': 'off',
+                '@typescript-eslint/restrict-template-expressions': 'off',
             },
         },
         {

--- a/examples/fast-csv-ts/examples/parse_and_format_transform_async.example.ts
+++ b/examples/fast-csv-ts/examples/parse_and_format_transform_async.example.ts
@@ -24,9 +24,7 @@ interface UserDetailsRow {
 fs.createReadStream(path.resolve(__dirname, '..', 'assets', 'snake_case_users.csv'))
     .pipe(csv.parse({ headers: true }))
     // pipe the parsed input into a csv formatter
-    .pipe(
-        csv.format<UserCsvRow, UserDetailsRow>({ headers: true }),
-    )
+    .pipe(csv.format<UserCsvRow, UserDetailsRow>({ headers: true }))
     // Using the transform function from the formatting stream
     .transform((row, next): void => {
         User.findById(+row.id, (err, user) => {

--- a/packages/format/__tests__/CsvFormatterStream.spec.ts
+++ b/packages/format/__tests__/CsvFormatterStream.spec.ts
@@ -93,11 +93,9 @@ describe('CsvFormatterStream', () => {
         });
 
         it('should error if the transform fails', async () => {
-            const formatter = new CsvFormatterStream(new FormatterOptions({ headers: true })).transform(
-                (): Row => {
-                    throw new Error('Expected error');
-                },
-            );
+            const formatter = new CsvFormatterStream(new FormatterOptions({ headers: true })).transform((): Row => {
+                throw new Error('Expected error');
+            });
             await expect(pipeToRecordingStream(formatter, objectRows)).rejects.toThrow('Expected error');
         });
     });

--- a/packages/format/src/formatter/RowFormatter.ts
+++ b/packages/format/src/formatter/RowFormatter.ts
@@ -156,7 +156,7 @@ export class RowFormatter<I extends Row, O extends Row> {
         }
         if (RowFormatter.isRowHashArray(row)) {
             return this.headers.map((header, i): string => {
-                const col = (row[i] as unknown) as string;
+                const col = row[i] as unknown as string;
                 if (col) {
                     return col[1];
                 }
@@ -173,7 +173,7 @@ export class RowFormatter<I extends Row, O extends Row> {
 
     private callTransformer(row: I, cb: RowTransformCallback<O>): void {
         if (!this._rowTransform) {
-            return cb(null, (row as unknown) as O);
+            return cb(null, row as unknown as O);
         }
         return this._rowTransform(row, cb);
     }

--- a/packages/parse/src/CsvParserStream.ts
+++ b/packages/parse/src/CsvParserStream.ts
@@ -169,7 +169,7 @@ export class CsvParserStream<I extends Row, O extends Row> extends Transform {
                 }
                 if (!withHeaders.isValid) {
                     if (this.shouldEmitRows) {
-                        return cb(null, { isValid: false, row: (parsedRow as never) as O });
+                        return cb(null, { isValid: false, row: parsedRow as never as O });
                     }
                     // skipped because of skipRows option remove from total row count
                     return this.skipRow(cb);

--- a/packages/parse/src/transforms/HeaderTransformer.ts
+++ b/packages/parse/src/transforms/HeaderTransformer.ts
@@ -71,7 +71,7 @@ export class HeaderTransformer<O extends Row> {
 
     private processRow(row: RowArray<string>): RowValidationResult<O> {
         if (!this.headers) {
-            return { row: (row as never) as O, isValid: true };
+            return { row: row as never as O, isValid: true };
         }
         const { parserOptions } = this;
         if (!parserOptions.discardUnmappedColumns && row.length > this.headersLength) {
@@ -81,14 +81,14 @@ export class HeaderTransformer<O extends Row> {
                 );
             }
             return {
-                row: (row as never) as O,
+                row: row as never as O,
                 isValid: false,
                 reason: `Column header mismatch expected: ${this.headersLength} columns got: ${row.length}`,
             };
         }
         if (parserOptions.strictColumnHandling && row.length < this.headersLength) {
             return {
-                row: (row as never) as O,
+                row: row as never as O,
                 isValid: false,
                 reason: `Column header mismatch expected: ${this.headersLength} columns got: ${row.length}`,
             };

--- a/packages/parse/src/transforms/RowTransformerValidator.ts
+++ b/packages/parse/src/transforms/RowTransformerValidator.ts
@@ -90,7 +90,7 @@ export class RowTransformerValidator<I extends Row, O extends Row> {
 
     private callTransformer(row: I, cb: RowTransformCallback<O>): void {
         if (!this._rowTransform) {
-            return cb(null, (row as never) as O);
+            return cb(null, row as never as O);
         }
         return this._rowTransform(row, cb);
     }


### PR DESCRIPTION
Remove broken plugin. Replace prettier with recommended plugin. Turn off some rules in example files. Auto-fix remaining errors.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/c2fo/fast-csv/pulls) for the same update/change?

Hi folks!  I was considering writing a possible enhancement to the lib so I forked but found that upon installing locally and firstly running `npm run test` that the linting was quite broken, so I thought I'd better have a go at fixing that first! 😄 

The first problem was a linting plugin which is now simply returning an error:

<img width="1444" alt="Screenshot_2021-11-10_at_23_18_43" src="https://user-images.githubusercontent.com/12282640/141209221-5a53f8c6-1510-4e94-bb88-47547d481e59.png">

In this case, according to the changelog linked in the error message, removing that and switching up `prettier` to `plugin:prettier/recommended` was the way to go:

> If you use eslint-plugin-prettier, all you need is plugin:prettier/recommended

Having done that, I still got a whole heap of errors from the linter, mainly the example.ts files, so I turned those off.  All of them had actually already been turned off in the js override below my new block in `.eslintrc.js`.

Thereafter there were still some errors, which I fixed with `npm run lint:fix`:

<img width="1445" alt="Screenshot_2021-11-10_at_22_55_50" src="https://user-images.githubusercontent.com/12282640/141209890-e9237461-e82c-4c05-83ac-3c28df904040.png">

`npm run test` was then completing successfully 👼 

