### PR TITLE
Fix for a small typo inside docs

### DIFF
--- a/documentation/docs/parsing/options.md
+++ b/documentation/docs/parsing/options.md
@@ -37,7 +37,7 @@ If you set to `null` then all quoting will be ignored.
 ## escape
 **Type**: `string` **Default**: `'"'`
 
-The character to used to escape quotes inside of a quoted field.
+The character to use to escape quotes inside of a quoted field.
 
 i.e: `First,"Name"' => '"First,""Name"""`
 


### PR DESCRIPTION
Found a typo in the docs for the escape option