### PR TITLE
Doc only: remove unneeded import

### DIFF
--- a/documentation/docs/parsing/methods.mdx
+++ b/documentation/docs/parsing/methods.mdx
@@ -108,7 +108,6 @@ Parses a file from the specified path and returns the `CsvParserStream`.
 <TabItem value="ts">
 
 ```ts
-import * as fs from 'fs';
 import { parseFile } from 'fast-csv';
 
 parseFile('my.csv')
@@ -121,7 +120,6 @@ parseFile('my.csv')
 <TabItem value="js">
 
 ```js
-const fs = require('fs');
 const csv = require('@fast-csv/parse');
 
 csv.parseFile('my.csv')


### PR DESCRIPTION
Advantage of using parseFile() is that 'import * as fs from 'fs';' can be omitted.

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/c2fo/fast-csv/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Have you added tests for the new feature
2. [ ] Does your submission pass tests?
3. [ ] Have you lint your code locally prior to submission?
4. [ ] Have you updated the docs?
    * [ ] If you added new parsing or formatting options have you added them to the docs?
    * [ ] If applicable have you added an example to the parsing or formatting docs? 

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?