### PR TITLE
Update links in README.md for packages

### DIFF
--- a/packages/fast-csv/README.md
+++ b/packages/fast-csv/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://c2fo.io/fast-csv" target="blank"><img src="https://c2fo.io/fast-csv/img/logo.svg" width="200" alt="fast-csv Logo" /></a>
+  <a href="https://c2fo.github.io/fast-csv" target="blank"><img src="https://c2fo.github.io/fast-csv/img/logo.svg" width="200" alt="fast-csv Logo" /></a>
 </p>
 
 [![npm version](https://img.shields.io/npm/v/fast-csv.svg)](https://www.npmjs.org/package/fast-csv)
@@ -9,12 +9,12 @@
 
 # `fast-csv`
 
-Package that combines both [`@fast-csv/format`](https://c2fo.io/fast-csv/docs/formatting/getting-started) and [`@fast-csv/parse`](https://c2fo.io/fast-csv/docs/parsing/getting-started) into a single package.
+Package that combines both [`@fast-csv/format`](https://c2fo.github.io/fast-csv/docs/formatting/getting-started) and [`@fast-csv/parse`](https://c2fo.github.io/fast-csv/docs/parsing/getting-started) into a single package.
 
 ## Installation
 
-[Install Guide](https://c2fo.io/fast-csv/docs/introduction/install)
+[Install Guide](https://c2fo.github.io/fast-csv/docs/introduction/install)
 
 ## Usage
 
-To get started with `fast-csv` [check out the docs](https://c2fo.io/fast-csv/docs/introduction/getting-started)
+To get started with `fast-csv` [check out the docs](https://c2fo.github.io/fast-csv/docs/introduction/getting-started)

--- a/packages/format/README.md
+++ b/packages/format/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://c2fo.io/fast-csv" target="blank"><img src="https://c2fo.io/fast-csv/img/logo.svg" width="200" alt="fast-csv Logo" /></a>
+  <a href="https://c2fo.github.io/fast-csv" target="blank"><img src="https://c2fo.github.io/fast-csv/img/logo.svg" width="200" alt="fast-csv Logo" /></a>
 </p>
 
 [![npm version](https://img.shields.io/npm/v/@fast-csv/format.svg)](https://www.npmjs.org/package/@fast-csv/format)
@@ -13,8 +13,8 @@
 
 ## Installation
 
-[Install Guide](https://c2fo.io/fast-csv/docs/introduction/install)
+[Install Guide](https://c2fo.github.io/fast-csv/docs/introduction/install)
 
 ## Usage
 
-To get started with `@fast-csv/format` [check out the docs](https://c2fo.io/fast-csv/docs/formatting/getting-started)
+To get started with `@fast-csv/format` [check out the docs](https://c2fo.github.io/fast-csv/docs/formatting/getting-started)

--- a/packages/parse/README.md
+++ b/packages/parse/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://c2fo.io/fast-csv" target="blank"><img src="https://c2fo.io/fast-csv/img/logo.svg" width="200" alt="fast-csv Logo" /></a>
+  <a href="https://c2fo.github.io/fast-csv" target="blank"><img src="https://c2fo.github.io/fast-csv/img/logo.svg" width="200" alt="fast-csv Logo" /></a>
 </p>
 
 [![npm version](https://img.shields.io/npm/v/@fast-csv/parse.svg)](https://www.npmjs.org/package/@fast-csv/parse)
@@ -13,8 +13,8 @@
 
 ## Installation
 
-[Install Guide](https://c2fo.io/fast-csv/docs/introduction/install)
+[Install Guide](https://c2fo.github.io/fast-csv/docs/introduction/install)
 
 ## Usage
 
-To get started with `@fast-csv/parse` [check out the docs](https://c2fo.io/fast-csv/docs/parsing/getting-started)
+To get started with `@fast-csv/parse` [check out the docs](https://c2fo.github.io/fast-csv/docs/parsing/getting-started)


### PR DESCRIPTION
Updated documentation links for package READMEs since they were broken on npmjs
Continuation on this PR from a few months ago https://github.com/C2FO/fast-csv/pull/828 

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/c2fo/fast-csv/pulls) for the same update/change?
