### PR TITLE
Remove lodash.isequal in favor of built-in array method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7548,15 +7548,6 @@
         "@types/lodash": "*"
       }
     },
-    "node_modules/@types/lodash.isequal": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz",
-      "integrity": "sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/@types/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
@@ -19134,11 +19125,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
     },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
-    },
     "node_modules/lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
@@ -29945,17 +29931,15 @@
       "dependencies": {
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isboolean": "^3.0.3",
-        "lodash.isequal": "^4.5.0",
         "lodash.isfunction": "^3.0.9",
         "lodash.isnil": "^4.0.0"
       },
       "devDependencies": {
         "@types/lodash.escaperegexp": "4.1.9",
         "@types/lodash.isboolean": "3.0.9",
-        "@types/lodash.isequal": "4.5.8",
         "@types/lodash.isfunction": "3.0.9",
         "@types/lodash.isnil": "4.0.9",
-        "@types/node": "^22.13.1"
+        "@types/node": "^22.7.8"
       }
     },
     "packages/parse": {
@@ -29978,7 +29962,7 @@
         "@types/lodash.isundefined": "3.0.9",
         "@types/lodash.partition": "4.6.9",
         "@types/lodash.uniq": "4.5.9",
-        "@types/node": "^22.13.1",
+        "@types/node": "^22.7.8",
         "@types/sinon": "17.0.3",
         "lodash.partition": "^4.6.0",
         "sinon": "19.0.2"

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -39,14 +39,12 @@
     "dependencies": {
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isboolean": "^3.0.3",
-        "lodash.isequal": "^4.5.0",
         "lodash.isfunction": "^3.0.9",
         "lodash.isnil": "^4.0.0"
     },
     "devDependencies": {
         "@types/lodash.escaperegexp": "4.1.9",
         "@types/lodash.isboolean": "3.0.9",
-        "@types/lodash.isequal": "4.5.8",
         "@types/lodash.isfunction": "3.0.9",
         "@types/lodash.isnil": "4.0.9",
         "@types/node": "^22.7.8"

--- a/packages/format/src/formatter/RowFormatter.ts
+++ b/packages/format/src/formatter/RowFormatter.ts
@@ -1,5 +1,4 @@
 import isFunction from 'lodash.isfunction';
-import isEqual from 'lodash.isequal';
 import { FormatterOptions } from '../FormatterOptions';
 import { FieldFormatter } from './FieldFormatter';
 import { isSyncTransform, Row, RowArray, RowHashArray, RowTransformCallback, RowTransformFunction } from '../types';
@@ -145,7 +144,10 @@ export class RowFormatter<I extends Row, O extends Row> {
             return { shouldFormatColumns: true, headers: null };
         }
         // if the row is equal to headers dont format
-        return { shouldFormatColumns: !isEqual(headers, row), headers };
+        if (Array.isArray(row) && headers.every((header, i): boolean => header === row[i])) {
+            return { shouldFormatColumns: false, headers };
+        }
+        return { shouldFormatColumns: true, headers };
     }
 
     // todo change this method to unknown[]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/c2fo/fast-csv/pulls) for the same update/change?

## Summary
I recently installed `fast-xml` as a replacement for `csv-stringify`, and while I was happy to see a bundle size reduction, I noticed that around half of the bundle size from its usage was coming from `lodash.isequal`.

I noticed that this package is only used for one call that can be easily replaced with a native call to `Array.every`. The result should shave around 10KB (roughly half the total size) off bundle sizes in the browser.

<img width="1204" alt="image" src="https://github.com/user-attachments/assets/653ffad5-2ce6-43ba-b844-9d3cc4d8cfe2">

## Test coverage
This case seems to be covering the case where `headers=true` is passed, but the headers are inferred from the first row, which is an array of strings, to prevent double-writing the headers. I verified that, when I changed this to `return true`, 33 tests failed, implying significant coverage of this case.

I also verified that there is a specific test covering exactly this behavior, at `RowFormatter.ts:119-124` (pasted here for clarity)

```ts
                describe('with headers=true', () => {
                    it('should only write the first row', async () => {
                        const formatter = createFormatter({ headers: true });
                        await expect(formatRow(headerRow, formatter)).resolves.toEqual([headerRow.join(',')]);
                    });
                });
```