### PR TITLE
chore(deps): replace some Lodash functions with vanilla JS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10035,15 +10035,6 @@
                 "@types/lodash": "*"
             }
         },
-        "node_modules/@types/lodash.isboolean": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@types/lodash.isboolean/-/lodash.isboolean-3.0.9.tgz",
-            "integrity": "sha512-7hl4ugsNFdRMKa9ORc46F4f10xJtQ1kMFI20IymakKEOzY5T4Xq5UBz+th3B9BpFuKmgSYGB725HscoqHAmPNQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
         "node_modules/@types/lodash.isfunction": {
             "version": "3.0.9",
             "resolved": "https://registry.npmjs.org/@types/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
@@ -35085,12 +35076,10 @@
             "license": "MIT",
             "dependencies": {
                 "lodash.escaperegexp": "^4.1.2",
-                "lodash.isboolean": "^3.0.3",
                 "lodash.isfunction": "^3.0.9"
             },
             "devDependencies": {
                 "@types/lodash.escaperegexp": "4.1.9",
-                "@types/lodash.isboolean": "3.0.9",
                 "@types/lodash.isfunction": "3.0.9",
                 "@types/node": "^22.7.8"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10035,15 +10035,6 @@
                 "@types/lodash": "*"
             }
         },
-        "node_modules/@types/lodash.isfunction": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@types/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
-            "integrity": "sha512-BLaDvlY09jnPND1wxlGXPrPl2CN4M7qGRah7Tb/rtB1vnLyZmtcw3FRPSUkDsd5n4e+2E5BBrr0ICfYR+S4hZQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
         "node_modules/@types/lodash.partition": {
             "version": "4.6.9",
             "resolved": "https://registry.npmjs.org/@types/lodash.partition/-/lodash.partition-4.6.9.tgz",
@@ -35075,12 +35066,10 @@
             "version": "5.0.5",
             "license": "MIT",
             "dependencies": {
-                "lodash.escaperegexp": "^4.1.2",
-                "lodash.isfunction": "^3.0.9"
+                "lodash.escaperegexp": "^4.1.2"
             },
             "devDependencies": {
                 "@types/lodash.escaperegexp": "4.1.9",
-                "@types/lodash.isfunction": "3.0.9",
                 "@types/node": "^22.7.8"
             }
         },
@@ -35091,13 +35080,11 @@
             "dependencies": {
                 "lodash.escaperegexp": "^4.1.2",
                 "lodash.groupby": "^4.6.0",
-                "lodash.isfunction": "^3.0.9",
                 "lodash.uniq": "^4.5.0"
             },
             "devDependencies": {
                 "@types/lodash.escaperegexp": "4.1.9",
                 "@types/lodash.groupby": "4.6.9",
-                "@types/lodash.isfunction": "3.0.9",
                 "@types/lodash.partition": "4.6.9",
                 "@types/lodash.uniq": "4.5.9",
                 "@types/node": "^22.7.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10053,15 +10053,6 @@
                 "@types/lodash": "*"
             }
         },
-        "node_modules/@types/lodash.isnil": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@types/lodash.isnil/-/lodash.isnil-4.0.9.tgz",
-            "integrity": "sha512-NruIMLXRJL8sOm1RZkzFBfoMIkLZ7hCNWaAXzzHiBTxf4JvQowcaP1l4eTr02jGJqCSEags/bPFN3ypUKMpgFw==",
-            "dev": true,
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
         "node_modules/@types/lodash.isundefined": {
             "version": "3.0.9",
             "resolved": "https://registry.npmjs.org/@types/lodash.isundefined/-/lodash.isundefined-3.0.9.tgz",
@@ -35104,14 +35095,12 @@
             "dependencies": {
                 "lodash.escaperegexp": "^4.1.2",
                 "lodash.isboolean": "^3.0.3",
-                "lodash.isfunction": "^3.0.9",
-                "lodash.isnil": "^4.0.0"
+                "lodash.isfunction": "^3.0.9"
             },
             "devDependencies": {
                 "@types/lodash.escaperegexp": "4.1.9",
                 "@types/lodash.isboolean": "3.0.9",
                 "@types/lodash.isfunction": "3.0.9",
-                "@types/lodash.isnil": "4.0.9",
                 "@types/node": "^22.7.8"
             }
         },
@@ -35123,7 +35112,6 @@
                 "lodash.escaperegexp": "^4.1.2",
                 "lodash.groupby": "^4.6.0",
                 "lodash.isfunction": "^3.0.9",
-                "lodash.isnil": "^4.0.0",
                 "lodash.isundefined": "^3.0.1",
                 "lodash.uniq": "^4.5.0"
             },
@@ -35131,7 +35119,6 @@
                 "@types/lodash.escaperegexp": "4.1.9",
                 "@types/lodash.groupby": "4.6.9",
                 "@types/lodash.isfunction": "3.0.9",
-                "@types/lodash.isnil": "4.0.9",
                 "@types/lodash.isundefined": "3.0.9",
                 "@types/lodash.partition": "4.6.9",
                 "@types/lodash.uniq": "4.5.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10053,15 +10053,6 @@
                 "@types/lodash": "*"
             }
         },
-        "node_modules/@types/lodash.isundefined": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@types/lodash.isundefined/-/lodash.isundefined-3.0.9.tgz",
-            "integrity": "sha512-nF+msH20xJzIJyZMBfArDnYxibF/Kt80y9naFYULzZ2yc4eBDAyxVDaf8DXyDWefHDh9CAaUoFp6XhMn38a26g==",
-            "dev": true,
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
         "node_modules/@types/lodash.partition": {
             "version": "4.6.9",
             "resolved": "https://registry.npmjs.org/@types/lodash.partition/-/lodash.partition-4.6.9.tgz",
@@ -35112,14 +35103,12 @@
                 "lodash.escaperegexp": "^4.1.2",
                 "lodash.groupby": "^4.6.0",
                 "lodash.isfunction": "^3.0.9",
-                "lodash.isundefined": "^3.0.1",
                 "lodash.uniq": "^4.5.0"
             },
             "devDependencies": {
                 "@types/lodash.escaperegexp": "4.1.9",
                 "@types/lodash.groupby": "4.6.9",
                 "@types/lodash.isfunction": "3.0.9",
-                "@types/lodash.isundefined": "3.0.9",
                 "@types/lodash.partition": "4.6.9",
                 "@types/lodash.uniq": "4.5.9",
                 "@types/node": "^22.7.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9062,16 +9062,6 @@
                 "@types/lodash": "*"
             }
         },
-        "node_modules/@types/lodash.isundefined": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@types/lodash.isundefined/-/lodash.isundefined-3.0.9.tgz",
-            "integrity": "sha512-nF+msH20xJzIJyZMBfArDnYxibF/Kt80y9naFYULzZ2yc4eBDAyxVDaf8DXyDWefHDh9CAaUoFp6XhMn38a26g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
         "node_modules/@types/lodash.partition": {
             "version": "4.6.9",
             "resolved": "https://registry.npmjs.org/@types/lodash.partition/-/lodash.partition-4.6.9.tgz",
@@ -21392,12 +21382,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/lodash.isundefined": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
-            "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
-            "license": "MIT"
-        },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -32914,14 +32898,12 @@
                 "lodash.escaperegexp": "^4.1.2",
                 "lodash.groupby": "^4.6.0",
                 "lodash.isfunction": "^3.0.9",
-                "lodash.isundefined": "^3.0.1",
                 "lodash.uniq": "^4.5.0"
             },
             "devDependencies": {
                 "@types/lodash.escaperegexp": "4.1.9",
                 "@types/lodash.groupby": "4.6.9",
                 "@types/lodash.isfunction": "3.0.9",
-                "@types/lodash.isundefined": "3.0.9",
                 "@types/lodash.partition": "4.6.9",
                 "@types/lodash.uniq": "4.5.9",
                 "@types/node": "^22.7.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9042,16 +9042,6 @@
                 "@types/lodash": "*"
             }
         },
-        "node_modules/@types/lodash.isfunction": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@types/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
-            "integrity": "sha512-BLaDvlY09jnPND1wxlGXPrPl2CN4M7qGRah7Tb/rtB1vnLyZmtcw3FRPSUkDsd5n4e+2E5BBrr0ICfYR+S4hZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
         "node_modules/@types/lodash.partition": {
             "version": "4.6.9",
             "resolved": "https://registry.npmjs.org/@types/lodash.partition/-/lodash.partition-4.6.9.tgz",
@@ -21353,12 +21343,6 @@
             "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
             "license": "MIT"
         },
-        "node_modules/lodash.isfunction": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
-            "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
-            "license": "MIT"
-        },
         "node_modules/lodash.ismatch": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -32846,12 +32830,10 @@
             "version": "5.0.5",
             "license": "MIT",
             "dependencies": {
-                "lodash.escaperegexp": "^4.1.2",
-                "lodash.isfunction": "^3.0.9"
+                "lodash.escaperegexp": "^4.1.2"
             },
             "devDependencies": {
                 "@types/lodash.escaperegexp": "4.1.9",
-                "@types/lodash.isfunction": "3.0.9",
                 "@types/node": "^22.7.8"
             }
         },
@@ -32879,13 +32861,11 @@
             "dependencies": {
                 "lodash.escaperegexp": "^4.1.2",
                 "lodash.groupby": "^4.6.0",
-                "lodash.isfunction": "^3.0.9",
                 "lodash.uniq": "^4.5.0"
             },
             "devDependencies": {
                 "@types/lodash.escaperegexp": "4.1.9",
                 "@types/lodash.groupby": "4.6.9",
-                "@types/lodash.isfunction": "3.0.9",
                 "@types/lodash.partition": "4.6.9",
                 "@types/lodash.uniq": "4.5.9",
                 "@types/node": "^22.7.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9062,16 +9062,6 @@
                 "@types/lodash": "*"
             }
         },
-        "node_modules/@types/lodash.isnil": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@types/lodash.isnil/-/lodash.isnil-4.0.9.tgz",
-            "integrity": "sha512-NruIMLXRJL8sOm1RZkzFBfoMIkLZ7hCNWaAXzzHiBTxf4JvQowcaP1l4eTr02jGJqCSEags/bPFN3ypUKMpgFw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
         "node_modules/@types/lodash.isundefined": {
             "version": "3.0.9",
             "resolved": "https://registry.npmjs.org/@types/lodash.isundefined/-/lodash.isundefined-3.0.9.tgz",
@@ -21402,12 +21392,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/lodash.isnil": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
-            "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
-            "license": "MIT"
-        },
         "node_modules/lodash.isundefined": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
@@ -32896,14 +32880,12 @@
             "dependencies": {
                 "lodash.escaperegexp": "^4.1.2",
                 "lodash.isboolean": "^3.0.3",
-                "lodash.isfunction": "^3.0.9",
-                "lodash.isnil": "^4.0.0"
+                "lodash.isfunction": "^3.0.9"
             },
             "devDependencies": {
                 "@types/lodash.escaperegexp": "4.1.9",
                 "@types/lodash.isboolean": "3.0.9",
                 "@types/lodash.isfunction": "3.0.9",
-                "@types/lodash.isnil": "4.0.9",
                 "@types/node": "^22.7.8"
             }
         },
@@ -32932,7 +32914,6 @@
                 "lodash.escaperegexp": "^4.1.2",
                 "lodash.groupby": "^4.6.0",
                 "lodash.isfunction": "^3.0.9",
-                "lodash.isnil": "^4.0.0",
                 "lodash.isundefined": "^3.0.1",
                 "lodash.uniq": "^4.5.0"
             },
@@ -32940,7 +32921,6 @@
                 "@types/lodash.escaperegexp": "4.1.9",
                 "@types/lodash.groupby": "4.6.9",
                 "@types/lodash.isfunction": "3.0.9",
-                "@types/lodash.isnil": "4.0.9",
                 "@types/lodash.isundefined": "3.0.9",
                 "@types/lodash.partition": "4.6.9",
                 "@types/lodash.uniq": "4.5.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9042,16 +9042,6 @@
                 "@types/lodash": "*"
             }
         },
-        "node_modules/@types/lodash.isboolean": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@types/lodash.isboolean/-/lodash.isboolean-3.0.9.tgz",
-            "integrity": "sha512-7hl4ugsNFdRMKa9ORc46F4f10xJtQ1kMFI20IymakKEOzY5T4Xq5UBz+th3B9BpFuKmgSYGB725HscoqHAmPNQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
         "node_modules/@types/lodash.isfunction": {
             "version": "3.0.9",
             "resolved": "https://registry.npmjs.org/@types/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
@@ -21363,12 +21353,6 @@
             "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
             "license": "MIT"
         },
-        "node_modules/lodash.isboolean": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-            "license": "MIT"
-        },
         "node_modules/lodash.isfunction": {
             "version": "3.0.9",
             "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
@@ -32863,12 +32847,10 @@
             "license": "MIT",
             "dependencies": {
                 "lodash.escaperegexp": "^4.1.2",
-                "lodash.isboolean": "^3.0.3",
                 "lodash.isfunction": "^3.0.9"
             },
             "devDependencies": {
                 "@types/lodash.escaperegexp": "4.1.9",
-                "@types/lodash.isboolean": "3.0.9",
                 "@types/lodash.isfunction": "3.0.9",
                 "@types/node": "^22.7.8"
             }

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -38,12 +38,10 @@
     },
     "dependencies": {
         "lodash.escaperegexp": "^4.1.2",
-        "lodash.isboolean": "^3.0.3",
         "lodash.isfunction": "^3.0.9"
     },
     "devDependencies": {
         "@types/lodash.escaperegexp": "4.1.9",
-        "@types/lodash.isboolean": "3.0.9",
         "@types/lodash.isfunction": "3.0.9",
         "@types/node": "^22.7.8"
     }

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -39,14 +39,12 @@
     "dependencies": {
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isboolean": "^3.0.3",
-        "lodash.isfunction": "^3.0.9",
-        "lodash.isnil": "^4.0.0"
+        "lodash.isfunction": "^3.0.9"
     },
     "devDependencies": {
         "@types/lodash.escaperegexp": "4.1.9",
         "@types/lodash.isboolean": "3.0.9",
         "@types/lodash.isfunction": "3.0.9",
-        "@types/lodash.isnil": "4.0.9",
         "@types/node": "^22.7.8"
     }
 }

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -37,12 +37,10 @@
         "url": "https://github.com/C2FO/fast-csv/issues"
     },
     "dependencies": {
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.isfunction": "^3.0.9"
+        "lodash.escaperegexp": "^4.1.2"
     },
     "devDependencies": {
         "@types/lodash.escaperegexp": "4.1.9",
-        "@types/lodash.isfunction": "3.0.9",
         "@types/node": "^22.7.8"
     }
 }

--- a/packages/format/src/formatter/FieldFormatter.ts
+++ b/packages/format/src/formatter/FieldFormatter.ts
@@ -1,4 +1,3 @@
-import isBoolean from 'lodash.isboolean';
 import escapeRegExp from 'lodash.escaperegexp';
 import { FormatterOptions } from '../FormatterOptions';
 import { Row } from '../types';
@@ -28,7 +27,7 @@ export class FieldFormatter<I extends Row, O extends Row> {
 
     private shouldQuote(fieldIndex: number, isHeader: boolean): boolean {
         const quoteConfig = isHeader ? this.formatterOptions.quoteHeaders : this.formatterOptions.quoteColumns;
-        if (isBoolean(quoteConfig)) {
+        if (typeof quoteConfig === 'boolean') {
             return quoteConfig;
         }
         if (Array.isArray(quoteConfig)) {

--- a/packages/format/src/formatter/FieldFormatter.ts
+++ b/packages/format/src/formatter/FieldFormatter.ts
@@ -1,5 +1,4 @@
 import isBoolean from 'lodash.isboolean';
-import isNil from 'lodash.isnil';
 import escapeRegExp from 'lodash.escaperegexp';
 import { FormatterOptions } from '../FormatterOptions';
 import { Row } from '../types';
@@ -42,7 +41,7 @@ export class FieldFormatter<I extends Row, O extends Row> {
     }
 
     public format(field: string, fieldIndex: number, isHeader: boolean): string {
-        const preparedField = `${isNil(field) ? '' : field}`.replace(/\0/g, '');
+        const preparedField = `${field ?? ''}`.replace(/\0/g, '');
         const { formatterOptions } = this;
         if (formatterOptions.quote !== '') {
             const shouldEscape = preparedField.indexOf(formatterOptions.quote) !== -1;

--- a/packages/format/src/formatter/RowFormatter.ts
+++ b/packages/format/src/formatter/RowFormatter.ts
@@ -1,4 +1,3 @@
-import isFunction from 'lodash.isfunction';
 import { FormatterOptions } from '../FormatterOptions';
 import { FieldFormatter } from './FieldFormatter';
 import { isSyncTransform, Row, RowArray, RowHashArray, RowTransformCallback, RowTransformFunction } from '../types';
@@ -82,7 +81,7 @@ export class RowFormatter<I extends Row, O extends Row> {
     }
 
     public set rowTransform(transformFunction: RowTransformFunction<I, O>) {
-        if (!isFunction(transformFunction)) {
+        if (typeof transformFunction !== 'function') {
             throw new TypeError('The transform should be a function');
         }
         this._rowTransform = RowFormatter.createTransform(transformFunction);

--- a/packages/parse/package.json
+++ b/packages/parse/package.json
@@ -40,13 +40,11 @@
     "dependencies": {
         "lodash.escaperegexp": "^4.1.2",
         "lodash.groupby": "^4.6.0",
-        "lodash.isfunction": "^3.0.9",
         "lodash.uniq": "^4.5.0"
     },
     "devDependencies": {
         "@types/lodash.escaperegexp": "4.1.9",
         "@types/lodash.groupby": "4.6.9",
-        "@types/lodash.isfunction": "3.0.9",
         "@types/lodash.partition": "4.6.9",
         "@types/lodash.uniq": "4.5.9",
         "@types/node": "^22.7.8",

--- a/packages/parse/package.json
+++ b/packages/parse/package.json
@@ -41,14 +41,12 @@
         "lodash.escaperegexp": "^4.1.2",
         "lodash.groupby": "^4.6.0",
         "lodash.isfunction": "^3.0.9",
-        "lodash.isundefined": "^3.0.1",
         "lodash.uniq": "^4.5.0"
     },
     "devDependencies": {
         "@types/lodash.escaperegexp": "4.1.9",
         "@types/lodash.groupby": "4.6.9",
         "@types/lodash.isfunction": "3.0.9",
-        "@types/lodash.isundefined": "3.0.9",
         "@types/lodash.partition": "4.6.9",
         "@types/lodash.uniq": "4.5.9",
         "@types/node": "^22.7.8",

--- a/packages/parse/package.json
+++ b/packages/parse/package.json
@@ -41,7 +41,6 @@
         "lodash.escaperegexp": "^4.1.2",
         "lodash.groupby": "^4.6.0",
         "lodash.isfunction": "^3.0.9",
-        "lodash.isnil": "^4.0.0",
         "lodash.isundefined": "^3.0.1",
         "lodash.uniq": "^4.5.0"
     },
@@ -49,7 +48,6 @@
         "@types/lodash.escaperegexp": "4.1.9",
         "@types/lodash.groupby": "4.6.9",
         "@types/lodash.isfunction": "3.0.9",
-        "@types/lodash.isnil": "4.0.9",
         "@types/lodash.isundefined": "3.0.9",
         "@types/lodash.partition": "4.6.9",
         "@types/lodash.uniq": "4.5.9",

--- a/packages/parse/src/ParserOptions.ts
+++ b/packages/parse/src/ParserOptions.ts
@@ -1,5 +1,4 @@
 import escapeRegExp from 'lodash.escaperegexp';
-import isNil from 'lodash.isnil';
 import { HeaderArray, HeaderTransformFunction } from './types';
 
 export interface ParserOptionsArgs {
@@ -76,7 +75,7 @@ export class ParserOptions {
         }
         this.escapedDelimiter = escapeRegExp(this.delimiter);
         this.escapeChar = this.escape ?? this.quote;
-        this.supportsComments = !isNil(this.comment);
+        this.supportsComments = this.comment != null;
         this.NEXT_TOKEN_REGEXP = new RegExp(`([^\\s]|\\r\\n|\\n|\\r|${this.escapedDelimiter})`);
 
         if (this.maxRows > 0) {

--- a/packages/parse/src/transforms/HeaderTransformer.ts
+++ b/packages/parse/src/transforms/HeaderTransformer.ts
@@ -1,4 +1,3 @@
-import isFunction from 'lodash.isfunction';
 import uniq from 'lodash.uniq';
 import groupBy from 'lodash.groupby';
 import { ParserOptions } from '../ParserOptions';
@@ -33,7 +32,7 @@ export class HeaderTransformer<O extends Row> {
             this.shouldUseFirstRow = true;
         } else if (Array.isArray(parserOptions.headers)) {
             this.setHeaders(parserOptions.headers);
-        } else if (isFunction(parserOptions.headers)) {
+        } else if (typeof parserOptions.headers === 'function') {
             this.headersTransform = parserOptions.headers;
         }
     }

--- a/packages/parse/src/transforms/HeaderTransformer.ts
+++ b/packages/parse/src/transforms/HeaderTransformer.ts
@@ -1,4 +1,3 @@
-import isUndefined from 'lodash.isundefined';
 import isFunction from 'lodash.isfunction';
 import uniq from 'lodash.uniq';
 import groupBy from 'lodash.groupby';
@@ -101,10 +100,10 @@ export class HeaderTransformer<O extends Row> {
         const { headers, headersLength } = this;
         for (let i = 0; i < headersLength; i += 1) {
             const header = (headers as string[])[i];
-            if (!isUndefined(header)) {
+            if (header !== undefined) {
                 const val = row[i];
 
-                if (isUndefined(val)) {
+                if (val === undefined) {
                     rowMap[header] = '';
                 } else {
                     rowMap[header] = val;

--- a/packages/parse/src/transforms/RowTransformerValidator.ts
+++ b/packages/parse/src/transforms/RowTransformerValidator.ts
@@ -1,4 +1,3 @@
-import isFunction from 'lodash.isfunction';
 import {
     Row,
     RowTransformFunction,
@@ -54,14 +53,14 @@ export class RowTransformerValidator<I extends Row, O extends Row> {
     private _rowValidator: RowValidator<O> | null = null;
 
     public set rowTransform(transformFunction: RowTransformFunction<I, O>) {
-        if (!isFunction(transformFunction)) {
+        if (typeof transformFunction !== 'function') {
             throw new TypeError('The transform should be a function');
         }
         this._rowTransform = RowTransformerValidator.createTransform(transformFunction);
     }
 
     public set rowValidator(validateFunction: RowValidate<O>) {
-        if (!isFunction(validateFunction)) {
+        if (typeof validateFunction !== 'function') {
             throw new TypeError('The validate should be a function');
         }
         this._rowValidator = RowTransformerValidator.createValidator(validateFunction);


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/c2fo/fast-csv/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

---

Heya, I have noticed that fast-csv pulls quite a lot of dependencies and got curious. I saw all of them are Lodash functions. I first wanted to propose replacing them with just Lodash (or, if you'd ask me, [es-toolkit](https://es-toolkit.dev/)), but Jordan's reasoning in #761 made me reconsider this.

I then noticed, however, that some Lodash functions you use are way too simple and could be replaced with vanilla JS. So, I did. See also #1038

- `_.isNil` => `== null`
  - yes, two equal signs, not three. This way it's also true for `undefined`, which is Lodash behaviour
  - in one place, I could replace it with nullish coalescing operator 
- `_.isUndefined` => `== undefined`
- `_.isBoolean` => `typeof ... === 'boolean'`
- `_.isFunction` => `typeof ... === 'function'`

This removes three dependencies from each `@fast-csv/format` and `@fast-csv/parse`. According to [pkg-size](https://pkg-size.dev/fast-csv), the removed packages attributed to 7.3% of the package's install size.

The replacements were taken from es-toolkit documentation, es-toolkit source code, or from common sense :) I haven't replaced other functions because they're not one-liners