### PR TITLE
fix(parse): ignore undefined options so defaults are preserved

### DIFF
--- a/packages/parse/__tests__/ParserOptions.spec.ts
+++ b/packages/parse/__tests__/ParserOptions.spec.ts
@@ -29,6 +29,10 @@ describe('ParserOptions', () => {
             expect(createOptions({ delimiter: '\\' }).delimiter).toBe('\\');
             expect(createOptions({ delimiter: '\\' }).escapedDelimiter).toBe('\\\\');
         });
+
+        it('should use the default delimiter when explicitly set to undefined', () => {
+            expect(createOptions({ delimiter: undefined }).delimiter).toBe(',');
+        });
     });
 
     describe('#strictColumnHandling', () => {

--- a/packages/parse/src/ParserOptions.ts
+++ b/packages/parse/src/ParserOptions.ts
@@ -69,7 +69,12 @@ export class ParserOptions {
     public readonly skipRows: number = 0;
 
     public constructor(opts?: ParserOptionsArgs) {
-        Object.assign(this, opts || {});
+        // Ignore explicitly-`undefined` options so they fall back to the defaults
+        // above instead of overwriting them (e.g. `{ delimiter: undefined }`).
+        const definedOpts = Object.entries(opts || {}).filter(([, value]) => {
+            return value !== undefined;
+        });
+        Object.assign(this, Object.fromEntries(definedOpts));
         if (this.delimiter.length > 1) {
             throw new Error('delimiter option must be one character long');
         }


### PR DESCRIPTION
## Problem

Closes #1160.

`ParserOptions` declares optional fields with defaults, then does `Object.assign(this, opts)`. Because `Object.assign` copies enumerable `undefined` values, explicitly passing an optional option as `undefined` overwrites its default. For `delimiter` this then throws:

```js
new ParserOptions({ delimiter: undefined });
// TypeError: Cannot read properties of undefined (reading 'length')
//   at new ParserOptions (.../ParserOptions.ts:73)  // this.delimiter.length
```

The options type marks every field optional (`delimiter?: string`), so passing `undefined` should be equivalent to omitting it — i.e. fall back to the default `,` — not blow up. This bites anyone forwarding options that themselves default to `undefined`.

## Fix

Filter out `undefined` entries before assigning, so defaults declared on the class are preserved:

```ts
const definedOpts = Object.entries(opts || {}).filter(([, value]) => {
    return value !== undefined;
});
Object.assign(this, Object.fromEntries(definedOpts));
```

This is general (any explicitly-`undefined` option now falls back to its default) and changes nothing for callers passing real values.

## Test plan

- [x] Added `ParserOptions` test: `{ delimiter: undefined }` resolves to the default `,`.
- [x] New test fails on `main` with the reported `TypeError`; passes with the fix.
- [x] `jest packages/parse` — **373 passing**, no regressions.
- [x] `eslint --max-warnings 0` and `prettier --check` clean on the changed files.