### PR TITLE
fix(format): write BOM when only headers are emitted for empty input

### DIFF
--- a/packages/format/__tests__/CsvFormatterStream.spec.ts
+++ b/packages/format/__tests__/CsvFormatterStream.spec.ts
@@ -429,4 +429,14 @@ describe('CsvFormatterStream', () => {
             }),
         ).resolves.toEqual(['\ufeff', 'a,b', '\na1,b1', '\na2,b2']);
     });
+
+    it('should write a BOM character with writeBOM when only headers are written for empty input', () => {
+        return expect(
+            formatRows([], {
+                headers: ['a', 'b'],
+                alwaysWriteHeaders: true,
+                writeBOM: true,
+            }),
+        ).resolves.toEqual(['\ufeff', 'a,b']);
+    });
 });

--- a/packages/format/src/CsvFormatterStream.ts
+++ b/packages/format/src/CsvFormatterStream.ts
@@ -57,7 +57,14 @@ export class CsvFormatterStream<I extends Row, O extends Row> extends Transform 
             if (err) {
                 return cb(err);
             }
-            if (rows) {
+            if (rows && rows.length > 0) {
+                // Headers may be flushed here with no preceding rows (e.g.
+                // `alwaysWriteHeaders` with an empty input), so _transform never
+                // ran and the BOM hasn't been written yet.
+                if (!this.hasWrittenBOM) {
+                    this.push(this.formatterOptions.BOM);
+                    this.hasWrittenBOM = true;
+                }
                 rows.forEach((r): void => {
                     this.push(Buffer.from(r, 'utf8'));
                 });


### PR DESCRIPTION
## Problem

Fixes #1148.

When the input rows array is empty, `writeBOM: true` is ignored even though headers are still written via `alwaysWriteHeaders`:

```ts
writeToString([], { headers: ['a', 'b'], alwaysWriteHeaders: true, writeBOM: true });
// => "a,b"   (expected: "﻿" + "a,b")
```

## Cause

`CsvFormatterStream` pushes the BOM only in `_transform`:

```ts
public _transform(row, encoding, cb) {
    if (!this.hasWrittenBOM) { this.push(this.formatterOptions.BOM); this.hasWrittenBOM = true; }
    ...
}
```

`_transform` runs once per row, so with an empty input it never fires. The headers are flushed later in `_flush` (via `rowFormatter.finish()` under `alwaysWriteHeaders`), which had no BOM handling — so the headers come out with no BOM.

## Fix

Write the BOM in `_flush` as well, guarded by `hasWrittenBOM` and only when `finish` actually produces content:

```ts
if (rows && rows.length > 0) {
    if (!this.hasWrittenBOM) { this.push(this.formatterOptions.BOM); this.hasWrittenBOM = true; }
    rows.forEach((r) => this.push(Buffer.from(r, 'utf8')));
}
```

The `rows.length > 0` guard keeps truly-empty output (no rows, no headers) from emitting a lone BOM, and `hasWrittenBOM` prevents a double BOM when rows were present.

## Test plan

- [x] Added a `CsvFormatterStream` test: `formatRows([], { headers: ['a','b'], alwaysWriteHeaders: true, writeBOM: true })` resolves to `['﻿', 'a,b']`.
- [x] New test fails on `main` and passes with the fix.
- [x] `jest packages/format` — **231 passing**; `eslint --max-warnings 0` + `prettier --check` clean.