### PR TITLE
fix(format): do not quote pipe fields by default

### DIFF
--- a/packages/format/__tests__/formatter/FieldFormatter.spec.ts
+++ b/packages/format/__tests__/formatter/FieldFormatter.spec.ts
@@ -78,6 +78,22 @@ describe('FieldFormatter', () => {
                 expect(formatter.format('col', 0, false)).toBe('col');
             });
 
+            it('should not quote the field if it only contains a pipe', () => {
+                const formatter = createFormatter();
+                expect(formatter.format('|', 0, false)).toBe('|');
+            });
+
+            it('should quote the field if it contains a pipe delimiter', () => {
+                const formatter = createFormatter({ delimiter: '|' });
+                expect(formatter.format('|', 0, false)).toBe('"|"');
+            });
+
+            it('should only quote the complete multi-character row delimiter', () => {
+                const formatter = createFormatter({ rowDelimiter: '||' });
+                expect(formatter.format('a|b', 0, false)).toBe('a|b');
+                expect(formatter.format('a||b', 0, false)).toBe('"a||b"');
+            });
+
             it('should quote the field and escape quotes if it contains a quote character', () => {
                 const formatter = createFormatter();
                 expect(formatter.format('c"o"l', 0, false)).toBe('"c""o""l"');

--- a/packages/format/src/formatter/FieldFormatter.ts
+++ b/packages/format/src/formatter/FieldFormatter.ts
@@ -17,7 +17,12 @@ export class FieldFormatter<I extends Row, O extends Row> {
             this.headers = formatterOptions.headers;
         }
         this.REPLACE_REGEXP = new RegExp(formatterOptions.quote, 'g');
-        const escapePattern = `[${formatterOptions.delimiter}${escapeRegExp(formatterOptions.rowDelimiter)}|\r|\n]`;
+        const escapePattern = [formatterOptions.delimiter, formatterOptions.rowDelimiter, '\r', '\n']
+            .filter((value) => {
+                return value.length > 0;
+            })
+            .map(escapeRegExp)
+            .join('|');
         this.ESCAPE_REGEXP = new RegExp(escapePattern);
     }
 


### PR DESCRIPTION
## Summary

- Build the formatter escape regexp from escaped literal delimiter, row delimiter, CR, and LF alternatives.
- Stop treating `|` as an escape trigger when the delimiter is still the default comma.
- Match multi-character row delimiters as complete strings instead of quoting on each constituent character.
- Ignore empty regexp alternatives so unsupported empty options cannot make every field match.
- Add regression coverage for default pipes, a configured pipe delimiter, and a multi-character `||` row delimiter.

Fixes #787.

## Why

The previous character-class regexp included `|` as a literal character while trying to express alternation. It also reduced multi-character row delimiters to sets of individual characters. As a result, plain pipe data could be quoted even when it did not contain the configured field or row delimiter.

## Verification

- `corepack pnpm exec jest packages/format/__tests__/formatter/FieldFormatter.spec.ts --runInBand` (24 tests)
- `corepack pnpm test` (37 suites, 606 tests, and all examples)
- `corepack pnpm run build` (7 workspace projects)
- `corepack pnpm run format:check`
- `git diff --check`
