### PR TITLE
fix(parse): preserve strict column mismatch reasons

### DIFF
--- a/packages/parse/__tests__/issues/issue772.spec.ts
+++ b/packages/parse/__tests__/issues/issue772.spec.ts
@@ -1,0 +1,45 @@
+import { EOL } from 'os';
+import { parseString, RowArray, RowMap } from '../../src';
+
+describe('Issue #772 - https://github.com/C2FO/fast-csv/issues/772', () => {
+    const CSV_CONTENT = ['header1,header2', 'test1,test2,test3', 'test4'].join(EOL);
+
+    it('preserves the strict column handling reason after transforming headers', () => {
+        return new Promise<void>((resolve, reject) => {
+            const invalidRows: RowArray[] = [];
+            const invalidReasons: string[] = [];
+            const rows: RowMap[] = [];
+
+            parseString(CSV_CONTENT, {
+                headers: (headers) => {
+                    return headers.map((header) => {
+                        return header?.toUpperCase();
+                    });
+                },
+                strictColumnHandling: true,
+            })
+                .on('data-invalid', (row: RowArray, _rowNumber: number, reason: string) => {
+                    invalidRows.push(row);
+                    invalidReasons.push(reason);
+                })
+                .on('data', (row: RowMap) => {
+                    rows.push(row);
+                })
+                .on('error', reject)
+                .on('end', (count: number) => {
+                    try {
+                        expect(rows).toEqual([]);
+                        expect(invalidRows).toEqual([['test1', 'test2', 'test3'], ['test4']]);
+                        expect(invalidReasons).toEqual([
+                            'Column header mismatch expected: 2 columns got: 3',
+                            'Column header mismatch expected: 2 columns got: 1',
+                        ]);
+                        expect(count).toBe(2);
+                        resolve();
+                    } catch (err) {
+                        reject(err instanceof Error ? err : new Error(String(err)));
+                    }
+                });
+        });
+    });
+});

--- a/packages/parse/src/CsvParserStream.ts
+++ b/packages/parse/src/CsvParserStream.ts
@@ -171,7 +171,7 @@ export class CsvParserStream<I extends Row, O extends Row> extends Transform {
                 }
                 if (!withHeaders.isValid) {
                     if (this.shouldEmitRows) {
-                        return cb(null, { isValid: false, row: parsedRow as O });
+                        return cb(null, { isValid: false, row: parsedRow as O, reason: withHeaders.reason });
                     }
                     // skipped because of skipRows option remove from total row count
                     return this.skipRow(cb);


### PR DESCRIPTION
## Summary

- Preserve `withHeaders.reason` when strict column handling marks a parsed row invalid.
- Add an issue regression test for header transformation plus strict column handling with both too many and too few columns.
- Exercise the public `data-invalid` event and verify rows, reasons, emitted data, and final row count.

Fixes #772.

## Why

`HeaderTransformer` already creates the `Column header mismatch...` reason, but `CsvParserStream.transformRow()` dropped that reason before emitting `data-invalid`. Consumers listening for the third `data-invalid` argument therefore received `undefined` even though the mismatch reason was known.

There was an earlier closed PR (#1112) for the same issue, but current `main` still reproduces the behavior. This version adds focused coverage for the exact reported path.

## Verification

- `corepack pnpm exec jest packages/parse/__tests__/issues/issue772.spec.ts --runInBand`
- `corepack pnpm test` (38 suites, 604 tests, and all examples)
- `corepack pnpm run build` (7 workspace projects)
- `corepack pnpm run format:check`
- `git diff --check`
