### PR TITLE
remove lodash.escaperegexp, lodash.groupby, and lodash.partition depe…

### DIFF
--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -36,11 +36,7 @@
     "bugs": {
         "url": "https://github.com/C2FO/fast-csv/issues"
     },
-    "dependencies": {
-        "lodash.escaperegexp": "^4.1.2"
-    },
     "devDependencies": {
-        "@types/lodash.escaperegexp": "4.1.9",
         "@types/node": "24.12.3"
     }
 }

--- a/packages/format/src/formatter/FieldFormatter.ts
+++ b/packages/format/src/formatter/FieldFormatter.ts
@@ -1,6 +1,7 @@
 import { FormatterOptions } from '../FormatterOptions';
 import { Row } from '../types';
 
+// TODO(major): use native RegExp.escape once engines require Node >=24 (available since Node 24)
 /** Escape special characters for use in a RegExp. */
 const escapeRegExp = (value: string): string => {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/packages/format/src/formatter/FieldFormatter.ts
+++ b/packages/format/src/formatter/FieldFormatter.ts
@@ -1,6 +1,10 @@
-import escapeRegExp from 'lodash.escaperegexp';
 import { FormatterOptions } from '../FormatterOptions';
 import { Row } from '../types';
+
+/** Escape special characters for use in a RegExp. */
+const escapeRegExp = (value: string): string => {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+};
 
 export class FieldFormatter<I extends Row, O extends Row> {
     private readonly formatterOptions: FormatterOptions<I, O>;

--- a/packages/parse/__tests__/CsvParsingStream.spec.ts
+++ b/packages/parse/__tests__/CsvParsingStream.spec.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as domain from 'domain';
-import partition from 'lodash.partition';
 import {
     ParserOptions,
     CsvParserStream,
@@ -11,6 +10,20 @@ import {
     RowValidateCallback,
     HeaderArray,
 } from '../src';
+
+/** Split array into [pass, fail] by predicate. */
+const partition = <T>(array: T[], predicate: (value: T) => boolean): [T[], T[]] => {
+    const pass: T[] = [];
+    const fail: T[] = [];
+    for (const value of array) {
+        if (predicate(value)) {
+            pass.push(value);
+        } else {
+            fail.push(value);
+        }
+    }
+    return [pass, fail];
+};
 import {
     PathAndContent,
     ParseResults,

--- a/packages/parse/package.json
+++ b/packages/parse/package.json
@@ -37,17 +37,9 @@
     "bugs": {
         "url": "https://github.com/C2FO/fast-csv/issues"
     },
-    "dependencies": {
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.groupby": "^4.6.0"
-    },
     "devDependencies": {
-        "@types/lodash.escaperegexp": "4.1.9",
-        "@types/lodash.groupby": "4.6.9",
-        "@types/lodash.partition": "4.6.9",
         "@types/node": "24.12.3",
         "@types/sinon": "21.0.1",
-        "lodash.partition": "^4.6.0",
         "sinon": "22.0.0"
     }
 }

--- a/packages/parse/src/ParserOptions.ts
+++ b/packages/parse/src/ParserOptions.ts
@@ -1,5 +1,9 @@
-import escapeRegExp from 'lodash.escaperegexp';
 import { HeaderArray, HeaderTransformFunction } from './types';
+
+/** Escape special characters for use in a RegExp. */
+const escapeRegExp = (value: string): string => {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+};
 
 export interface ParserOptionsArgs {
     objectMode?: boolean;

--- a/packages/parse/src/ParserOptions.ts
+++ b/packages/parse/src/ParserOptions.ts
@@ -1,5 +1,6 @@
 import { HeaderArray, HeaderTransformFunction } from './types';
 
+// TODO(major): use native RegExp.escape once engines require Node >=24 (available since Node 24)
 /** Escape special characters for use in a RegExp. */
 const escapeRegExp = (value: string): string => {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/packages/parse/src/transforms/HeaderTransformer.ts
+++ b/packages/parse/src/transforms/HeaderTransformer.ts
@@ -1,4 +1,3 @@
-import groupBy from 'lodash.groupby';
 import { ParserOptions } from '../ParserOptions';
 import {
     HeaderArray,
@@ -112,11 +111,14 @@ export class HeaderTransformer<O extends Row> {
     }
 
     private setHeaders(headers: HeaderArray): void {
-        const filteredHeaders = headers.filter((h) => {
+        const filteredHeaders = headers.filter((h): h is string => {
             return !!h;
         });
         if (new Set(filteredHeaders).size !== filteredHeaders.length) {
-            const grouped = groupBy(filteredHeaders);
+            const grouped = filteredHeaders.reduce<Record<string, string[]>>((acc, header) => {
+                (acc[header] ||= []).push(header);
+                return acc;
+            }, {});
             const duplicates = Object.keys(grouped).filter((dup) => {
                 return grouped[dup].length > 1;
             });

--- a/packages/parse/src/transforms/HeaderTransformer.ts
+++ b/packages/parse/src/transforms/HeaderTransformer.ts
@@ -115,6 +115,7 @@ export class HeaderTransformer<O extends Row> {
             return !!h;
         });
         if (new Set(filteredHeaders).size !== filteredHeaders.length) {
+            // TODO(major): use Object.groupBy once engines require Node >=22 (available since Node 21)
             const grouped = filteredHeaders.reduce<Record<string, string[]>>((acc, header) => {
                 (acc[header] ||= []).push(header);
                 return acc;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,45 +210,19 @@ importers:
         version: link:../parse
 
   packages/format:
-    dependencies:
-      lodash.escaperegexp:
-        specifier: ^4.1.2
-        version: 4.1.2
     devDependencies:
-      '@types/lodash.escaperegexp':
-        specifier: 4.1.9
-        version: 4.1.9
       '@types/node':
         specifier: 24.12.3
         version: 24.12.3
 
   packages/parse:
-    dependencies:
-      lodash.escaperegexp:
-        specifier: ^4.1.2
-        version: 4.1.2
-      lodash.groupby:
-        specifier: ^4.6.0
-        version: 4.6.0
     devDependencies:
-      '@types/lodash.escaperegexp':
-        specifier: 4.1.9
-        version: 4.1.9
-      '@types/lodash.groupby':
-        specifier: 4.6.9
-        version: 4.6.9
-      '@types/lodash.partition':
-        specifier: 4.6.9
-        version: 4.6.9
       '@types/node':
         specifier: 24.12.3
         version: 24.12.3
       '@types/sinon':
         specifier: 21.0.1
         version: 21.0.1
-      lodash.partition:
-        specifier: ^4.6.0
-        version: 4.6.0
       sinon:
         specifier: 22.0.0
         version: 22.0.0
@@ -2703,18 +2677,6 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-
-  '@types/lodash.escaperegexp@4.1.9':
-    resolution: {integrity: sha512-CMQc8v16YzhnPZnMhYQuJUksI8BmL1jy/lHJkiXi4/t24Lx7Qvy7qxew1abrDJGa1T2i0NzLLaR27NK1/qp5Ow==}
-
-  '@types/lodash.groupby@4.6.9':
-    resolution: {integrity: sha512-z2xtCX2ko7GrqORnnYea4+ksT7jZNAvaOcLd6mP9M7J09RHvJs06W8BGdQQAX8ARef09VQLdeRilSOcfHlDQJQ==}
-
-  '@types/lodash.partition@4.6.9':
-    resolution: {integrity: sha512-ANgnHyTw/C07oHr/8/jzoc1BlZZFRafAyDvc04Z8qR1IvWZpAGB8aHPUkd0UCgJWOauqoCsILhvPLXKsTc4rXQ==}
-
-  '@types/lodash@4.17.24':
-    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -5836,12 +5798,6 @@ packages:
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
-  lodash.escaperegexp@4.1.2:
-    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
-
-  lodash.groupby@4.6.0:
-    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
-
   lodash.ismatch@4.4.0:
     resolution: {integrity: sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==}
 
@@ -5850,9 +5806,6 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-
-  lodash.partition@4.6.0:
-    resolution: {integrity: sha512-35L3dSF3Q6V1w5j6V3NhNlQjzsRDC/pYKCTdYTmwqSib+Q8ponkAmt/PwEOq3EmI38DSCl+SkIVwLd+uSlVdrg==}
 
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
@@ -12394,20 +12347,6 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/lodash.escaperegexp@4.1.9':
-    dependencies:
-      '@types/lodash': 4.17.24
-
-  '@types/lodash.groupby@4.6.9':
-    dependencies:
-      '@types/lodash': 4.17.24
-
-  '@types/lodash.partition@4.6.9':
-    dependencies:
-      '@types/lodash': 4.17.24
-
-  '@types/lodash@4.17.24': {}
-
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -16103,17 +16042,11 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
-  lodash.escaperegexp@4.1.2: {}
-
-  lodash.groupby@4.6.0: {}
-
   lodash.ismatch@4.4.0: {}
 
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
-
-  lodash.partition@4.6.0: {}
 
   lodash.uniq@4.5.0: {}
 


### PR DESCRIPTION
Removing the last lodash dependencies, should reduce bundle size especially for the parse package. 

This would make format and parse dependency free. 

### All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/c2fo/fast-csv/pulls) for the same update/change?


### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
